### PR TITLE
Activity calendar bug

### DIFF
--- a/src/main/java/db/migration/V165__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup.java
+++ b/src/main/java/db/migration/V165__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup.java
@@ -1,0 +1,114 @@
+package db.migration;
+
+import edu.ucdavis.dss.ipa.api.helpers.Utilities;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import java.sql.*;
+
+public class V165__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup implements JdbcMigration {
+
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        // Find all activities
+        // Is the activity associated to a section?
+        // If the section has a numeric sequenceNumber, add a sectionGroup association and remove the section association
+
+        PreparedStatement psActivities = connection.prepareStatement("SELECT * FROM `Activities`");
+
+        try {
+            connection.setAutoCommit(false);
+
+            ResultSet rsActivities = psActivities.executeQuery();
+
+            while (rsActivities.next()) {
+                long activityId = rsActivities.getLong("Id");
+                long sectionId = rsActivities.getLong("SectionId");
+                long sectionGroupId = rsActivities.getLong("SectionGroupId");
+
+                if (sectionGroupId > 0) {
+                    continue;
+                }
+
+                // Find Section
+                PreparedStatement psSection = connection.prepareStatement(
+                        "SELECT * FROM `Sections` WHERE `Id` = ? ;"
+                );
+
+                psSection.setLong(1, sectionId);
+
+                ResultSet rsSection = psSection.executeQuery();
+                while (rsSection.next()) {
+                    sectionGroupId = rsSection.getLong("SectionGroupId");
+                }
+
+                // Find SectionGroup
+                long courseId = 0L;
+                String sequencePattern = null;
+
+                PreparedStatement psSectionGroup = connection.prepareStatement(
+                    "SELECT * FROM `SectionGroups` WHERE `Id` = ? ;"
+                );
+
+                psSectionGroup.setLong(1, sectionGroupId);
+
+                ResultSet rsSectionGroup = psSectionGroup.executeQuery();
+                while (rsSectionGroup.next()) {
+                    courseId = rsSectionGroup.getLong("CourseId");
+                }
+
+                // Find Course
+                PreparedStatement psCourse = connection.prepareStatement(
+                        "SELECT * FROM `Courses` WHERE `Id` = ? ;"
+                );
+
+                psCourse.setLong(1, courseId);
+
+                ResultSet rsCourse = psCourse.executeQuery();
+                while (rsCourse.next()) {
+                    sequencePattern = rsCourse.getString("SequencePattern");
+                }
+
+                // If this is a letter based sectionGroup, then skip
+                if (Utilities.isNumeric(sequencePattern) == false) {
+                    continue;
+                }
+
+                // Add sectionGroup association
+                PreparedStatement psAddSectionGroup = connection.prepareStatement(
+                    " UPDATE `Activities` SET `SectionGroupId` = ? WHERE `Id` = ?;"
+                );
+
+                psAddSectionGroup.setLong(1, sectionGroupId);
+                psAddSectionGroup.setLong(2, activityId);
+
+                psAddSectionGroup.execute();
+                psAddSectionGroup.close();
+
+                // Remove section association
+                PreparedStatement psRemoveSection = connection.prepareStatement(
+                    " UPDATE `Activities` SET `SectionId` = NULL WHERE `Id` = ?;"
+                );
+
+                psRemoveSection.setLong(1, activityId);
+
+                psRemoveSection.execute();
+                psRemoveSection.close();
+            } // End rsActivities loop
+
+            // Commit changes
+            connection.commit();
+
+        } catch(SQLException e) {
+            e.printStackTrace();
+            return;
+        } finally {
+            try {
+                if (psActivities != null) {
+                    psActivities.close();
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/db/migration/V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup.java
+++ b/src/main/java/db/migration/V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup.java
@@ -5,7 +5,7 @@ import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
 import java.sql.*;
 
-public class V165__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup implements JdbcMigration {
+public class V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup implements JdbcMigration {
 
     @Override
     public void migrate(Connection connection) throws Exception {

--- a/src/main/java/db/migration/V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup.java
+++ b/src/main/java/db/migration/V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_SectionGroup.java
@@ -37,14 +37,11 @@ public class V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_
                 psSection.setLong(1, sectionId);
 
                 ResultSet rsSection = psSection.executeQuery();
-                while (rsSection.next()) {
-                    sectionGroupId = rsSection.getLong("SectionGroupId");
-                }
+                rsSection.next();
+
+                sectionGroupId = rsSection.getLong("SectionGroupId");
 
                 // Find SectionGroup
-                long courseId = 0L;
-                String sequencePattern = null;
-
                 PreparedStatement psSectionGroup = connection.prepareStatement(
                     "SELECT * FROM `SectionGroups` WHERE `Id` = ? ;"
                 );
@@ -52,9 +49,9 @@ public class V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_
                 psSectionGroup.setLong(1, sectionGroupId);
 
                 ResultSet rsSectionGroup = psSectionGroup.executeQuery();
-                while (rsSectionGroup.next()) {
-                    courseId = rsSectionGroup.getLong("CourseId");
-                }
+                rsSectionGroup.next();
+
+                long courseId = rsSectionGroup.getLong("CourseId");
 
                 // Find Course
                 PreparedStatement psCourse = connection.prepareStatement(
@@ -64,9 +61,9 @@ public class V166__Ensure_Activities_Of_Numeric_SectionGroups_Are_Associated_To_
                 psCourse.setLong(1, courseId);
 
                 ResultSet rsCourse = psCourse.executeQuery();
-                while (rsCourse.next()) {
-                    sequencePattern = rsCourse.getString("SequencePattern");
-                }
+                rsCourse.next();
+
+                String sequencePattern = rsCourse.getString("SequencePattern");
 
                 // If this is a letter based sectionGroup, then skip
                 if (Utilities.isNumeric(sequencePattern) == false) {

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
@@ -6,6 +6,7 @@ import edu.ucdavis.dss.ipa.api.components.course.views.CourseView;
 import edu.ucdavis.dss.ipa.api.components.course.views.SectionGroupImport;
 import edu.ucdavis.dss.ipa.api.components.course.views.factories.AnnualViewFactory;
 import edu.ucdavis.dss.ipa.api.components.course.views.factories.JpaAnnualViewFactory;
+import edu.ucdavis.dss.ipa.api.helpers.Utilities;
 import edu.ucdavis.dss.ipa.config.SettingsConfiguration;
 import edu.ucdavis.dss.ipa.entities.*;
 import edu.ucdavis.dss.ipa.entities.enums.ActivityState;
@@ -25,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.sql.Time;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -397,7 +399,13 @@ public class CourseViewController {
 						activity.setEndDate(term.getEndDate());
 						activity.setActivityState(ActivityState.DRAFT);
 
-						activity.setSection(section);
+						// Activities in numeric sectionGroups should always be 'shared' activities
+						if (Utilities.isNumeric(dwSequencePattern)) {
+							activity.setSectionGroup(sectionGroup);
+						} else {
+							activity.setSection(section);
+						}
+
 						activityService.saveActivity(activity);
 					}
 				}

--- a/src/main/java/edu/ucdavis/dss/ipa/api/helpers/Utilities.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/helpers/Utilities.java
@@ -52,8 +52,17 @@ public class Utilities {
         return output.toString();
     }
 
-    public static boolean isNumeric(String str)
-    {
-        return str.matches("-?\\d+(\\.\\d+)?");  //match a number with optional '-' and decimal.
+    public static boolean isNumeric(String str) {
+        if (str == null | str.length() == 0) {
+            return false;
+        }
+
+        for (int i = 0; i < str.length(); i++) {
+            if (!Character.isDigit(str.charAt(i))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/api/helpers/Utilities.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/helpers/Utilities.java
@@ -51,4 +51,9 @@ public class Utilities {
         }
         return output.toString();
     }
+
+    public static boolean isNumeric(String str)
+    {
+        return str.matches("-?\\d+(\\.\\d+)?");  //match a number with optional '-' and decimal.
+    }
 }


### PR DESCRIPTION
When performing a course import from banner, activities from numeric sections (example: GEL 181L 001) are created and should be associated to the sectionGroup, but are being associated to the section. (In this context, they show up on the calendar in the UI, but are not editable).

This PR ensures that during course import when those activities are created, are appropriately tied to the sectionGroup.

It also includes a migration to fix any activities that have been inappropriately associated to their section.