### PR TITLE
Assignments: Handle partial existence of suggested course when approving preference

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -166,7 +166,9 @@ public class AssignmentViewTeachingAssignmentController {
                     // Necessary sectionGroup did not exist, need to create it
                     if (sectionGroup == null) {
                         sectionGroup = new SectionGroup();
-
+                        sectionGroup.setTermCode(teachingAssignment.getTermCode());
+                        sectionGroup.setCourse(slotCourse);
+                        sectionGroup = sectionGroupService.save(sectionGroup);
                     }
                 }
             } else {


### PR DESCRIPTION
Bug was caused when a course existed in a schedule for some terms but not others, and then an instructor suggested it for a new term, and then the academic planner approved it for that new term.

That specific logic branch identified a sectionGroup was needed, but did not persist the sectionGroup.