### PR TITLE
CoursesView: Banner import should properly set activity end time

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
@@ -514,8 +514,8 @@ public class CourseViewController {
 							String rawEndTime = dwActivity.getSsrmeet_end_time();
 
 							if (rawEndTime != null) {
-								String hours = rawStartTime.substring(0, 2);
-								String minutes = rawStartTime.substring(2, 4);
+								String hours = rawEndTime.substring(0, 2);
+								String minutes = rawEndTime.substring(2, 4);
 								String formattedEndTime = hours + ":" + minutes + ":00";
 								Time endTime = java.sql.Time.valueOf(formattedEndTime);
 


### PR DESCRIPTION
When importing banner activity times, the backend was erroneously setting start and end time based on the start time of the banner activity.

github issue:
https://github.com/ucdavis/ipa-client-angular/issues/1443