### PR TITLE
InstructorSupportCallForm: Initial payload should also include all relevant support staff

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/instructionalSupport/views/factories/JpaInstructionalSupportViewFactory.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/instructionalSupport/views/factories/JpaInstructionalSupportViewFactory.java
@@ -203,7 +203,7 @@ public class JpaInstructionalSupportViewFactory implements InstructionalSupportV
             instructorPreferences.addAll(slotSectionGroup.getInstructorSupportPreferences());
         }
 
-        List<SupportStaff> supportStaffList = supportStaffService.findActiveByWorkgroupId(workgroupId);
+        List<SupportStaff> supportStaffList = supportStaffService.findByWorkgroupIdAndPreferences(workgroupId, studentPreferences);
 
         return new InstructionalSupportCallInstructorFormView(sectionGroups, courses, studentPreferences, instructorPreferences, supportStaffList, schedule.getId(), instructorId, instructorSupportCallResponse);
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/SupportStaffService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/SupportStaffService.java
@@ -1,5 +1,6 @@
 package edu.ucdavis.dss.ipa.services;
 
+import edu.ucdavis.dss.ipa.entities.StudentSupportPreference;
 import edu.ucdavis.dss.ipa.entities.SupportAssignment;
 import edu.ucdavis.dss.ipa.entities.SupportStaff;
 
@@ -19,4 +20,6 @@ public interface SupportStaffService {
     List<SupportStaff> findByScheduleId(long id);
 
     List<SupportStaff> findBySupportAssignments(List<SupportAssignment> supportAssignments);
+
+    List<SupportStaff> findByWorkgroupIdAndPreferences(long workgroupId, List<StudentSupportPreference> studentPreferences);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSupportStaffService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSupportStaffService.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class JpaSupportStaffService implements SupportStaffService {
@@ -144,19 +145,9 @@ public class JpaSupportStaffService implements SupportStaffService {
 
     @Override
     public List<SupportStaff> findByWorkgroupIdAndPreferences(long workgroupId, List<StudentSupportPreference> studentPreferences) {
-        Set<SupportStaff> preferredSupportStaff = new LinkedHashSet<>();
+        Set<SupportStaff> supportStaff = new LinkedHashSet<>(studentPreferences.stream().map(preference -> preference.getSupportStaff()).collect(Collectors.toList()));
+        supportStaff.addAll(new LinkedHashSet<>(this.findActiveByWorkgroupId(workgroupId)));
 
-        for (StudentSupportPreference preference : studentPreferences) {
-            if (preference.getSupportStaff() != null) {
-                preferredSupportStaff.add(preference.getSupportStaff());
-            }
-        }
-
-        Set<SupportStaff> activeSupportStaff = new LinkedHashSet<>(this.findActiveByWorkgroupId(workgroupId));
-        preferredSupportStaff.addAll(activeSupportStaff);
-
-        List<SupportStaff> supportStaffList = new ArrayList<>(preferredSupportStaff);
-
-        return supportStaffList;
+        return new ArrayList<>(supportStaff);
     }
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSupportStaffService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSupportStaffService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class JpaSupportStaffService implements SupportStaffService {
@@ -136,6 +138,24 @@ public class JpaSupportStaffService implements SupportStaffService {
                 supportStaffList.add(supportAssignment.getSupportStaff());
             }
         }
+
+        return supportStaffList;
+    }
+
+    @Override
+    public List<SupportStaff> findByWorkgroupIdAndPreferences(long workgroupId, List<StudentSupportPreference> studentPreferences) {
+        Set<SupportStaff> preferredSupportStaff = new LinkedHashSet<>();
+
+        for (StudentSupportPreference preference : studentPreferences) {
+            if (preference.getSupportStaff() != null) {
+                preferredSupportStaff.add(preference.getSupportStaff());
+            }
+        }
+
+        Set<SupportStaff> activeSupportStaff = new LinkedHashSet<>(this.findActiveByWorkgroupId(workgroupId));
+        preferredSupportStaff.addAll(activeSupportStaff);
+
+        List<SupportStaff> supportStaffList = new ArrayList<>(preferredSupportStaff);
 
         return supportStaffList;
     }


### PR DESCRIPTION
Currently only active support staff are included in the payload,
inactive support staff who had indicated preferences are not included.

issue:
https://github.com/ucdavis/ipa-client-angular/issues/1455