### PR TITLE
Feature/ Rename scenarios and don't allow last scenario to be deleted

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
@@ -230,6 +230,28 @@ public class BudgetViewController {
         return budgetService.update(budgetDTO);
     }
 
+    @RequestMapping(value = "/api/budgetView/budgetScenarios/{budgetScenarioId}", method = RequestMethod.PUT, produces="application/json")
+    @ResponseBody
+    public BudgetScenario updateBudgetScenario(@PathVariable long budgetScenarioId,
+                               @RequestBody BudgetScenario newBudgetScenario,
+                               HttpServletResponse httpResponse) {
+        // Ensure valid params
+        BudgetScenario budgetScenario = budgetScenarioService.findById(budgetScenarioId);
+
+        if (budgetScenario == null) {
+            httpResponse.setStatus(HttpStatus.NOT_FOUND.value());
+            return null;
+        }
+
+        // Authorization check
+        Long workGroupId = budgetScenario.getBudget().getSchedule().getWorkgroup().getId();
+        authorizer.hasWorkgroupRoles(workGroupId, "academicPlanner", "reviewer");
+
+        budgetScenario.setName(newBudgetScenario.getName());
+
+        return budgetScenarioService.update(budgetScenario);
+    }
+
     @RequestMapping(value = "/api/budgetView/instructorCosts/{instructorCostId}", method = RequestMethod.PUT, produces="application/json")
     @ResponseBody
     public InstructorCost updateInstructorCost(@PathVariable long instructorCostId,

--- a/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/BudgetScenarioDeserializer.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/BudgetScenarioDeserializer.java
@@ -1,0 +1,34 @@
+package edu.ucdavis.dss.ipa.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import edu.ucdavis.dss.ipa.entities.*;
+
+public class BudgetScenarioDeserializer extends JsonDeserializer<Object> {
+
+    @Override
+    public Object deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException, JsonProcessingException {
+        ObjectCodec oc = jsonParser.getCodec();
+        JsonNode node = oc.readTree(jsonParser);
+
+        BudgetScenario budgetScenario = new BudgetScenario();
+
+        if (node.has("id")) {
+            budgetScenario.setId(node.get("id").longValue());
+        }
+
+        if (node.has("name")) {
+            budgetScenario.setName(node.get("name").textValue());
+        }
+
+        return budgetScenario;
+    }
+}

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/BudgetScenario.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/BudgetScenario.java
@@ -1,6 +1,5 @@
 package edu.ucdavis.dss.ipa.entities;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +9,8 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import edu.ucdavis.dss.ipa.api.deserializers.BudgetScenarioDeserializer;
 
 /**
  * Budget is used to record information common to all budget scenarios.
@@ -17,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SuppressWarnings("serial")
 @Entity
+@JsonDeserialize(using = BudgetScenarioDeserializer.class)
 @Table(name = "BudgetScenarios")
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class BudgetScenario extends BaseEntity {

--- a/src/main/java/edu/ucdavis/dss/ipa/services/BudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/BudgetScenarioService.java
@@ -13,4 +13,6 @@ public interface BudgetScenarioService {
     void deleteById(long budgetScenarioId);
 
     BudgetScenario createFromExisting(Long scenarioId, String name);
+
+    BudgetScenario update(BudgetScenario budgetScenario);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -103,6 +103,11 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
     }
 
     @Override
+    public BudgetScenario update(BudgetScenario budgetScenario) {
+        return budgetScenarioRepository.save(budgetScenario);
+    }
+
+    @Override
     public BudgetScenario findById(long budgetScenarioId) {
         return budgetScenarioRepository.findById(budgetScenarioId);
     }


### PR DESCRIPTION
1) Adds service layer/routes for editing budget scenario names

Issue:
https://trello.com/c/HTzf3sQh/198-budgetview-ability-to-rename-a-scenario-disability-to-delete-last-scenario