### PR TITLE
TeachingCall: Fixes a bug in preference sorting

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -439,19 +439,11 @@ public class AssignmentViewTeachingAssignmentController {
         Workgroup workgroup = schedule.getWorkgroup();
         authorizer.hasWorkgroupRoles(workgroup.getId(), "academicPlanner", "federationInstructor", "senateInstructor", "lecturer");
 
-        Integer priority = 1;
-
-        List<TeachingAssignment> teachingAssignments = teachingAssignmentService.findAllByIds(sortedTeachingPreferenceIds);
+        List<TeachingAssignment> teachingAssignments = teachingAssignmentService.updatePreferenceOrder(sortedTeachingPreferenceIds);
 
         if (teachingAssignments == null || teachingAssignments.size() != sortedTeachingPreferenceIds.size()) {
             httpResponse.setStatus(HttpStatus.NOT_FOUND.value());
             return null;
-        }
-
-        for(TeachingAssignment teachingAssignment : teachingAssignments) {
-            teachingAssignment.setPriority(priority);
-            teachingAssignmentService.save(teachingAssignment);
-            priority++;
         }
 
         return sortedTeachingPreferenceIds;

--- a/src/main/java/edu/ucdavis/dss/ipa/services/TeachingAssignmentService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/TeachingAssignmentService.java
@@ -37,4 +37,6 @@ public interface TeachingAssignmentService {
 	TeachingAssignment findByTeachingAssignment(TeachingAssignment teachingAssignment);
 
 	List<TeachingAssignment> findAllByIds(List<Long> teachingAssignmentIds);
+
+	List<TeachingAssignment> updatePreferenceOrder(List<Long> sortedTeachingPreferenceIds);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingAssignmentService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingAssignmentService.java
@@ -139,4 +139,26 @@ public class JpaTeachingAssignmentService implements TeachingAssignmentService {
 		return teachingAssignmentRepository.findByIdIn(teachingAssignmentIds);
 	}
 
+	@Override
+	public List<TeachingAssignment> updatePreferenceOrder(List<Long> sortedTeachingPreferenceIds) {
+		List<TeachingAssignment> teachingAssignments = this.findAllByIds(sortedTeachingPreferenceIds);
+
+		if (teachingAssignments == null) {
+			return null;
+		}
+
+		Integer priority = 1;
+
+		for (Long id : sortedTeachingPreferenceIds) {
+			for(TeachingAssignment teachingAssignment : teachingAssignments) {
+				if (id == teachingAssignment.getId()) {
+					teachingAssignment.setPriority(priority);
+					this.save(teachingAssignment);
+					priority++;
+				}
+			}
+		}
+
+		return teachingAssignments;
+	}
 }


### PR DESCRIPTION
This appears to have broken during a refactoring, when we had hibernate query all the assignments from a list of Ids, we didn't verify the returned assignments were in the sorted order.


Issue:
https://trello.com/c/LiHIEGiL/1538-teachingcall-users-cannot-set-preference-priority