### PR TITLE
When creating lineItems from teachingAssignment update, should use persisted teachingAssignment

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -20,6 +20,7 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
     @Inject CourseService courseService;
     @Inject LineItemCategoryService lineItemCategoryService;
     @Inject BudgetService budgetService;
+    @Inject TeachingAssignmentService teachingAssignmentService;
 
     @Override
     @Transactional
@@ -148,8 +149,10 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
     }
 
     @Override
-    public void createLineItemsFromTeachingAssignment(TeachingAssignment teachingAssignment) {
-        if (teachingAssignment.isApproved() && (teachingAssignment.isBuyout() || teachingAssignment.isWorkLifeBalance())) {
+    public void createLineItemsFromTeachingAssignment(TeachingAssignment teachingAssignmentDTO) {
+        if (teachingAssignmentDTO.isApproved() && (teachingAssignmentDTO.isBuyout() || teachingAssignmentDTO.isWorkLifeBalance())) {
+            TeachingAssignment teachingAssignment = teachingAssignmentService.findOneById(teachingAssignmentDTO.getId());
+
             Budget budget = budgetService.findOrCreateByWorkgroupIdAndYear(teachingAssignment.getSchedule().getWorkgroup().getId(), teachingAssignment.getSchedule().getYear());
 
             for (BudgetScenario budgetScenario : budget.getBudgetScenarios()) {


### PR DESCRIPTION
When creating lineItems from an updated teachingAssignment, it should query the persisted teachingAssignment to ensure nested resources are accessible.

Additionally, in the current sprint we will be stripping out this logic to sync lineItem entities, and instead just calculate lineItems implicitly.

Issue:
https://trello.com/c/Vu5nqqJr/1543-mvc-exception-in-assignmentview