### PR TITLE
BudgetView: Should use BigDecimal for handling currency values

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/InstructorCostDeserializer.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/InstructorCostDeserializer.java
@@ -27,7 +27,7 @@ public class InstructorCostDeserializer extends JsonDeserializer<Object> {
 
         if (node.has("cost")) {
             if (node.get("cost").isNull() == false) {
-                instructorCost.setCost(node.get("cost").floatValue());
+                instructorCost.setCost(node.get("cost").decimalValue());
             }
         }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/LineItemDeserializer.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/LineItemDeserializer.java
@@ -1,6 +1,7 @@
 package edu.ucdavis.dss.ipa.api.deserializers;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -46,7 +47,7 @@ public class LineItemDeserializer extends JsonDeserializer<Object> {
         }
 
         if (node.has("amount")) {
-            float amount = node.get("amount").floatValue();
+            BigDecimal amount = node.get("amount").decimalValue();
             lineItem.setAmount(amount);
         }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/SectionGroupCostDeserializer.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/SectionGroupCostDeserializer.java
@@ -30,7 +30,7 @@ public class SectionGroupCostDeserializer extends JsonDeserializer<Object> {
 
         if (node.has("cost")) {
             if (!node.get("cost").isNull()) {
-                sectionGroupCost.setCost(node.get("cost").floatValue());
+                sectionGroupCost.setCost(node.get("cost").decimalValue());
             }
         }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/InstructorCost.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/InstructorCost.java
@@ -1,6 +1,6 @@
 package edu.ucdavis.dss.ipa.entities;
 
-import java.io.Serializable;
+import java.math.BigDecimal;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -9,9 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import edu.ucdavis.dss.ipa.api.deserializers.ActivityDeserializer;
 import edu.ucdavis.dss.ipa.api.deserializers.InstructorCostDeserializer;
-import edu.ucdavis.dss.ipa.api.deserializers.LineItemDeserializer;
 
 @SuppressWarnings("serial")
 @Entity
@@ -22,7 +20,7 @@ public class InstructorCost extends BaseEntity {
     private long id;
     private Budget budget;
     private Instructor instructor;
-    private Float cost;
+    private BigDecimal cost;
     private Boolean lecturer = false;
     private InstructorType instructorType;
 
@@ -75,11 +73,11 @@ public class InstructorCost extends BaseEntity {
         this.instructorType = instructorType;
     }
 
-    public Float getCost() {
+    public BigDecimal getCost() {
         return cost;
     }
 
-    public void setCost(Float cost) {
+    public void setCost(BigDecimal cost) {
         this.cost = cost;
     }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
@@ -1,6 +1,6 @@
 package edu.ucdavis.dss.ipa.entities;
 
-import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import edu.ucdavis.dss.ipa.api.deserializers.ActivityDeserializer;
 import edu.ucdavis.dss.ipa.api.deserializers.LineItemDeserializer;
 
 @SuppressWarnings("serial")
@@ -23,7 +22,7 @@ import edu.ucdavis.dss.ipa.api.deserializers.LineItemDeserializer;
 public class LineItem extends BaseEntity {
     private long id;
     private BudgetScenario budgetScenario;
-    private float amount = 0f;
+    private BigDecimal amount = new BigDecimal(0);
     private String description, notes;
     private LineItemCategory lineItemCategory;
     private List<LineItemComment> lineItemComments = new ArrayList<>();
@@ -54,11 +53,11 @@ public class LineItem extends BaseEntity {
         this.budgetScenario = budgetScenario;
     }
 
-    public float getAmount() {
+    public BigDecimal getAmount() {
         return amount;
     }
 
-    public void setAmount(float amount) {
+    public void setAmount(BigDecimal amount) {
         this.amount = amount;
     }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/SectionGroupCost.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/SectionGroupCost.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.ucdavis.dss.ipa.api.deserializers.SectionGroupCostDeserializer;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +27,8 @@ public class SectionGroupCost extends BaseEntity {
     private Instructor instructor;
     private Instructor originalInstructor;
     private String reason;
-    private Float cost, taCount, readerCount;
+    private BigDecimal cost;
+    private Float taCount, readerCount;
     private List<SectionGroupCostComment> sectionGroupCostComments = new ArrayList<>();
 
     @Id
@@ -87,11 +89,11 @@ public class SectionGroupCost extends BaseEntity {
         this.readerCount = readerCount;
     }
 
-    public Float getCost() {
+    public BigDecimal getCost() {
         return cost;
     }
 
-    public void setCost(Float cost) {
+    public void setCost(BigDecimal cost) {
         this.cost = cost;
     }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -73,7 +74,7 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
             if (teachingAssignment.isBuyout()) {
                 LineItem lineItemDTO = new LineItem();
                 lineItemDTO.setBudgetScenario(budgetScenario);
-                lineItemDTO.setAmount(0f);
+                lineItemDTO.setAmount(new BigDecimal(0));
                 lineItemDTO.setLineItemCategory(lineItemCategoryService.findById(2));
 
                 String description = teachingAssignment.getInstructor().getFullName() + " Buyout Funds for " + Term.getRegistrarName(teachingAssignment.getTermCode());
@@ -84,7 +85,7 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
             } else if (teachingAssignment.isWorkLifeBalance()) {
                 LineItem lineItemDTO = new LineItem();
                 lineItemDTO.setBudgetScenario(budgetScenario);
-                lineItemDTO.setAmount(0f);
+                lineItemDTO.setAmount(new BigDecimal(0));
                 lineItemDTO.setLineItemCategory(lineItemCategoryService.findById(5));
 
                 String description = teachingAssignment.getInstructor().getFullName() + " Work-Life Balance Funds for " + Term.getRegistrarName(teachingAssignment.getTermCode());
@@ -125,7 +126,7 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
         budgetScenario.setActiveTermsBlob(originalBudgetScenario.getActiveTermsBlob());
         budgetScenario = budgetScenarioRepository.save(budgetScenario);
 
-        List<SectionGroupCost> sectionGroupCostList = new ArrayList<>();
+        List<SectionGroupCost> sectionGroupCostList = budgetScenario.getSectionGroupCosts();
 
         // Clone sectionGroupCosts
         for(SectionGroupCost originalSectionGroupCost : originalBudgetScenario.getSectionGroupCosts()) {

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
+import java.math.BigDecimal;
 import java.util.List;
 
 @Service
@@ -98,7 +98,7 @@ public class JpaLineItemService implements LineItemService {
         }
 
         LineItem lineItemDTO = new LineItem();
-        lineItemDTO.setAmount(0f);
+        lineItemDTO.setAmount(new BigDecimal(0));
         lineItemDTO.setBudgetScenario(budgetScenario);
 
         String description = "";

--- a/src/main/resources/db/migration/V185__Update_instructorCost_to_decimal.sql
+++ b/src/main/resources/db/migration/V185__Update_instructorCost_to_decimal.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `InstructorCosts` CHANGE COLUMN `Cost` `Cost` decimal(30,2) NULL;
+ALTER TABLE `LineItems` CHANGE COLUMN `Amount` `Amount` decimal(30,2) NULL;


### PR DESCRIPTION
Issue:
https://trello.com/c/gZpyJpHg/1549-budgetview-when-entering-a-general-instructor-cost-entering-a-large-value-with-cents-causes-cents-to-be-truncated