### PR TITLE
Feature/live line items

### DIFF
--- a/src/main/java/db/migration/V188__Remove_persist_lineItems_that_should_be_implicit.java
+++ b/src/main/java/db/migration/V188__Remove_persist_lineItems_that_should_be_implicit.java
@@ -1,0 +1,66 @@
+package db.migration;
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import java.math.BigDecimal;
+import java.sql.*;
+
+public class V188__Remove_persist_lineItems_that_should_be_implicit implements JdbcMigration {
+
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        // Find all lineItems
+
+        PreparedStatement psLineItems = connection.prepareStatement("SELECT * FROM `LineItems`");
+
+        try {
+            connection.setAutoCommit(false);
+
+            ResultSet rsLineItems = psLineItems.executeQuery();
+
+            while (rsLineItems.next()) {
+                long lineItemId = rsLineItems.getLong("Id");
+                BigDecimal amount = rsLineItems.getBigDecimal("amount");
+                String description = rsLineItems.getString("description");
+
+                // Should not delete if description doesn't match auto-generated pattern
+                // Look for string 'buyout funds for' or 'work-life balance funds for
+                // TODO
+
+                // Should not delete if a cost was set
+                if (amount.compareTo(BigDecimal.ZERO) > 0) {
+                    continue;
+                }
+
+                // Should not delete if comments were made
+                PreparedStatement psComments = connection.prepareStatement("SELECT COUNT(*) FROM `LineItemComments` WHERE `LineItemId` = ?");
+                psComments.setLong(1, lineItemId);
+                ResultSet rsComments = psComments.executeQuery();
+
+                if(rsComments.next()) {
+                    // Comments were found
+                    continue;
+                }
+
+                psComments.close();
+
+                // Delete lineItem
+            }
+
+            // Commit changes
+            connection.commit();
+
+        } catch(SQLException e) {
+            e.printStackTrace();
+            return;
+        } finally {
+            try {
+                if (psLineItems != null) {
+                    psLineItems.close();
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/db/migration/V188__Remove_persist_lineItems_that_should_be_implicit.java
+++ b/src/main/java/db/migration/V188__Remove_persist_lineItems_that_should_be_implicit.java
@@ -37,17 +37,13 @@ public class V188__Remove_persist_lineItems_that_should_be_implicit implements J
                 }
 
                 // Should not delete if comments were made
-                PreparedStatement psComments = connection.prepareStatement("SELECT * FROM `LineItemComments` WHERE `LineItemId` = ?");
+                PreparedStatement psComments = connection.prepareStatement("SELECT COUNT(*) AS commentCount FROM `LineItemComments` WHERE `LineItemId` = ?");
                 psComments.setLong(1, lineItemId);
 
                 ResultSet rsComments = psComments.executeQuery();
-                Boolean commentsFound = false;
+                rsComments.next();
 
-                while (rsComments.next()) {
-                    commentsFound = true;
-                }
-
-                if (commentsFound) {
+                if (rsComments.getLong("commentCount") > 0) {
                     continue;
                 }
 

--- a/src/main/java/db/migration/V188__Remove_persist_lineItems_that_should_be_implicit.java
+++ b/src/main/java/db/migration/V188__Remove_persist_lineItems_that_should_be_implicit.java
@@ -17,6 +17,9 @@ public class V188__Remove_persist_lineItems_that_should_be_implicit implements J
 
             ResultSet rsLineItems = psLineItems.executeQuery();
 
+            String buyoutDescription = "Buyout Funds for";
+            String workDescription = "Work-Life Balance Funds for";
+
             while (rsLineItems.next()) {
                 long lineItemId = rsLineItems.getLong("Id");
                 BigDecimal amount = rsLineItems.getBigDecimal("amount");
@@ -24,9 +27,6 @@ public class V188__Remove_persist_lineItems_that_should_be_implicit implements J
 
                 // Should not delete if description doesn't match auto-generated pattern
                 // Look for string 'buyout funds for' or 'work-life balance funds for
-                String buyoutDescription = "Buyout Funds for";
-                String workDescription = "Work-Life Balance Funds for";
-
                 if (description.contains(buyoutDescription) == false && description.contains(workDescription) == false) {
                     continue;
                 }

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -76,7 +76,6 @@ public class AssignmentViewTeachingAssignmentController {
             teachingAssignment.setSchedule(schedule);
 
             TeachingAssignment newTeachingAssignment = teachingAssignmentService.save(teachingAssignment);
-            budgetScenarioService.createLineItemsFromTeachingAssignment(newTeachingAssignment);
 
             return newTeachingAssignment;
         }
@@ -214,10 +213,6 @@ public class AssignmentViewTeachingAssignmentController {
             originalTeachingAssignment.setSuggestedEffectiveTermCode(teachingAssignment.getSuggestedEffectiveTermCode());
 
             return originalTeachingAssignment;
-        }
-
-        if (originalTeachingAssignment.isApproved() == false && teachingAssignment.isApproved()) {
-            budgetScenarioService.createLineItemsFromTeachingAssignment(teachingAssignment);
         }
 
         originalTeachingAssignment.setApproved(teachingAssignment.isApproved());

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
@@ -14,6 +14,7 @@ import edu.ucdavis.dss.ipa.entities.LineItemComment;
 import edu.ucdavis.dss.ipa.entities.SectionGroup;
 import edu.ucdavis.dss.ipa.entities.SectionGroupCost;
 import edu.ucdavis.dss.ipa.entities.SectionGroupCostComment;
+import edu.ucdavis.dss.ipa.entities.TeachingAssignment;
 import edu.ucdavis.dss.ipa.entities.User;
 import edu.ucdavis.dss.ipa.security.Authorizer;
 import edu.ucdavis.dss.ipa.services.BudgetScenarioService;
@@ -27,6 +28,7 @@ import edu.ucdavis.dss.ipa.services.LineItemService;
 import edu.ucdavis.dss.ipa.services.SectionGroupCostCommentService;
 import edu.ucdavis.dss.ipa.services.SectionGroupCostService;
 import edu.ucdavis.dss.ipa.services.SectionGroupService;
+import edu.ucdavis.dss.ipa.services.TeachingAssignmentService;
 import edu.ucdavis.dss.ipa.services.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -53,6 +55,7 @@ public class BudgetViewController {
     @Inject SectionGroupService sectionGroupService;
     @Inject InstructorTypeService instructorTypeService;
     @Inject InstructorService instructorService;
+    @Inject TeachingAssignmentService teachingAssignmentService;
 
     /**
      * Delivers the JSON payload for the Courses View (nee Annual View), used on page load.
@@ -155,6 +158,11 @@ public class BudgetViewController {
         if (budgetScenario == null) {
             httpResponse.setStatus(HttpStatus.NOT_FOUND.value());
             return null;
+        }
+
+        if (lineItemDTO.getTeachingAssignment() != null) {
+            TeachingAssignment teachingAssignment = teachingAssignmentService.findOneById(lineItemDTO.getTeachingAssignment().getId());
+            lineItemDTO.setTeachingAssignment(teachingAssignment);
         }
 
         // Authorization check

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/views/factories/JpaBudgetViewFactory.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/views/factories/JpaBudgetViewFactory.java
@@ -84,7 +84,6 @@ public class JpaBudgetViewFactory implements BudgetViewFactory {
         List<SectionGroupCostComment> sectionGroupCostComments = sectionGroupCostCommentService.findBySectionGroupCosts(sectionGroupCosts);
         List<LineItemComment> lineItemComments = lineItemCommentService.findByLineItems(lineItems);
         List<TeachingAssignment> teachingAssignments = teachingAssignmentService.findByScheduleId(schedule.getId());
-
         List<SupportAssignment> supportAssignments = supportAssignmentService.findBySectionGroups(sectionGroups);
 
         Set<User> users = new HashSet<> (userService.findAllByWorkgroupAndRoleToken(workgroup, "academicPlanner"));

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/views/factories/JpaBudgetViewFactory.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/views/factories/JpaBudgetViewFactory.java
@@ -84,6 +84,7 @@ public class JpaBudgetViewFactory implements BudgetViewFactory {
         List<SectionGroupCostComment> sectionGroupCostComments = sectionGroupCostCommentService.findBySectionGroupCosts(sectionGroupCosts);
         List<LineItemComment> lineItemComments = lineItemCommentService.findByLineItems(lineItems);
         List<TeachingAssignment> teachingAssignments = teachingAssignmentService.findByScheduleId(schedule.getId());
+
         List<SupportAssignment> supportAssignments = supportAssignmentService.findBySectionGroups(sectionGroups);
 
         Set<User> users = new HashSet<> (userService.findAllByWorkgroupAndRoleToken(workgroup, "academicPlanner"));

--- a/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/LineItemDeserializer.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/LineItemDeserializer.java
@@ -38,6 +38,12 @@ public class LineItemDeserializer extends JsonDeserializer<Object> {
             lineItem.setLineItemCategory(lineItemCategory);
         }
 
+        if (node.has("teachingAssignmentId")) {
+            TeachingAssignment teachingAssignment = new TeachingAssignment();
+            teachingAssignment.setId(node.get("teachingAssignmentId").longValue());
+            lineItem.setTeachingAssignment(teachingAssignment);
+        }
+
         if (node.has("description")) {
             lineItem.setDescription(node.get("description").textValue());
         }

--- a/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/LineItemDeserializer.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/deserializers/LineItemDeserializer.java
@@ -52,6 +52,10 @@ public class LineItemDeserializer extends JsonDeserializer<Object> {
             lineItem.setNotes(node.get("notes").textValue());
         }
 
+        if (node.has("hidden")) {
+            lineItem.setHidden(node.get("hidden").booleanValue());
+        }
+
         if (node.has("amount")) {
             BigDecimal amount = node.get("amount").decimalValue();
             lineItem.setAmount(amount);

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
@@ -79,12 +79,12 @@ public class LineItem extends BaseEntity {
         this.notes = notes;
     }
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "TeachingAssignmentId", nullable = true)
-    @JsonIgnore
     /**
      * May reference a teachingAssignment that no longer exists. Orphaning is intentional to allow user to decide whether or not to delete.
      */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "TeachingAssignmentId", nullable = true)
+    @JsonIgnore
     public TeachingAssignment getTeachingAssignment() {
         return teachingAssignment;
     }
@@ -137,7 +137,7 @@ public class LineItem extends BaseEntity {
 
     @JsonProperty("teachingAssignmentId")
     @Transient
-    public Long getTeachingAssignmentIdentification() {
+    public Long getTeachingAssignmentIdIfExists() {
         if(teachingAssignment != null) {
             return teachingAssignment.getId();
         } else {

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
@@ -26,6 +26,8 @@ public class LineItem extends BaseEntity {
     private String description, notes;
     private LineItemCategory lineItemCategory;
     private List<LineItemComment> lineItemComments = new ArrayList<>();
+    private Boolean hidden = false;
+    private TeachingAssignment teachingAssignment;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -78,6 +80,18 @@ public class LineItem extends BaseEntity {
     }
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "TeachingAssignmentId", nullable = true)
+    @NotNull
+    @JsonIgnore
+    public TeachingAssignment getTeachingAssignment() {
+        return teachingAssignment;
+    }
+
+    public void setTeachingAssignment(TeachingAssignment teachingAssignment) {
+        this.teachingAssignment = teachingAssignment;
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "LineItemCategoryId", nullable = false)
     @NotNull
     @JsonIgnore
@@ -99,6 +113,15 @@ public class LineItem extends BaseEntity {
         this.lineItemComments = lineItemComments;
     }
 
+    @JsonProperty
+    public Boolean getHidden() {
+        return hidden;
+    }
+
+    public void setHidden(Boolean hidden) {
+        this.hidden = hidden;
+    }
+
     @JsonProperty("lineItemCategoryId")
     @Transient
     public long getLineItemCategoryId() {
@@ -106,6 +129,16 @@ public class LineItem extends BaseEntity {
             return lineItemCategory.getId();
         } else {
             return 0;
+        }
+    }
+
+    @JsonProperty("teachingAssignmentId")
+    @Transient
+    public Long getTeachingAssignmentIdentification() {
+        if(teachingAssignment != null) {
+            return teachingAssignment.getId();
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
@@ -82,6 +82,9 @@ public class LineItem extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TeachingAssignmentId", nullable = true)
     @JsonIgnore
+    /**
+     * May reference a teachingAssignment that no longer exists. Orphaning is intentional to allow user to decide whether or not to delete.
+     */
     public TeachingAssignment getTeachingAssignment() {
         return teachingAssignment;
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/LineItem.java
@@ -81,7 +81,6 @@ public class LineItem extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TeachingAssignmentId", nullable = true)
-    @NotNull
     @JsonIgnore
     public TeachingAssignment getTeachingAssignment() {
         return teachingAssignment;
@@ -113,6 +112,7 @@ public class LineItem extends BaseEntity {
         this.lineItemComments = lineItemComments;
     }
 
+    @NotNull
     @JsonProperty
     public Boolean getHidden() {
         return hidden;

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/TeachingAssignment.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/TeachingAssignment.java
@@ -6,6 +6,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.ucdavis.dss.ipa.api.deserializers.TeachingAssignmentDeserializer;
@@ -18,6 +19,7 @@ import edu.ucdavis.dss.ipa.api.deserializers.TeachingAssignmentDeserializer;
 @SuppressWarnings("serial")
 @Entity
 @Table(name = "TeachingAssignments")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 @JsonDeserialize(using = TeachingAssignmentDeserializer.class)
 public class TeachingAssignment implements Serializable {
 	private long id;

--- a/src/main/java/edu/ucdavis/dss/ipa/services/BudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/BudgetScenarioService.java
@@ -16,6 +16,4 @@ public interface BudgetScenarioService {
     BudgetScenario createFromExisting(Long scenarioId, String name);
 
     BudgetScenario update(BudgetScenario budgetScenario);
-
-    void createLineItemsFromTeachingAssignment(TeachingAssignment teachingAssignment);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/LineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/LineItemService.java
@@ -23,6 +23,4 @@ public interface LineItemService {
     LineItem createDuplicate(LineItem originalLineItem, BudgetScenario budgetScenario);
 
     void deleteMany(List<Long> lineItemIds);
-
-    void createLineItemFromTeachingAssignmentAndBudgetScenario(TeachingAssignment teachingAssignment, BudgetScenario budgetScenario);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -157,19 +157,6 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
     }
 
     @Override
-    public void createLineItemsFromTeachingAssignment(TeachingAssignment teachingAssignmentDTO) {
-        if (teachingAssignmentDTO.isApproved() && (teachingAssignmentDTO.isBuyout() || teachingAssignmentDTO.isWorkLifeBalance())) {
-            TeachingAssignment teachingAssignment = teachingAssignmentService.findOneById(teachingAssignmentDTO.getId());
-
-            Budget budget = budgetService.findOrCreateByWorkgroupIdAndYear(teachingAssignment.getSchedule().getWorkgroup().getId(), teachingAssignment.getSchedule().getYear());
-
-            for (BudgetScenario budgetScenario : budget.getBudgetScenarios()) {
-                lineItemService.createLineItemFromTeachingAssignmentAndBudgetScenario(teachingAssignment, budgetScenario);
-            }
-        }
-    }
-
-    @Override
     public BudgetScenario findById(long budgetScenarioId) {
         return budgetScenarioRepository.findById(budgetScenarioId);
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
@@ -50,6 +50,7 @@ public class JpaLineItemService implements LineItemService {
         lineItem.setNotes(lineItemDTO.getNotes());
         lineItem.setDescription(lineItemDTO.getDescription());
         lineItem.setTeachingAssignment(lineItemDTO.getTeachingAssignment());
+        lineItem.setHidden(lineItemDTO.getHidden());
 
         return lineItemRepository.save(lineItem);
     }
@@ -66,6 +67,7 @@ public class JpaLineItemService implements LineItemService {
         originalLineItem.setAmount(lineItem.getAmount());
         originalLineItem.setNotes(lineItem.getNotes());
         originalLineItem.setLineItemCategory(lineItem.getLineItemCategory());
+        originalLineItem.setHidden(lineItem.getHidden());
 
         return this.lineItemRepository.save(originalLineItem);
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
@@ -49,6 +49,7 @@ public class JpaLineItemService implements LineItemService {
         lineItem.setAmount(lineItemDTO.getAmount());
         lineItem.setNotes(lineItemDTO.getNotes());
         lineItem.setDescription(lineItemDTO.getDescription());
+        lineItem.setTeachingAssignment(lineItemDTO.getTeachingAssignment());
 
         return lineItemRepository.save(lineItem);
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
@@ -90,29 +90,4 @@ public class JpaLineItemService implements LineItemService {
             this.deleteById(lineItemId);
         }
     }
-
-    @Override
-    public void createLineItemFromTeachingAssignmentAndBudgetScenario(TeachingAssignment teachingAssignment, BudgetScenario budgetScenario) {
-        if (teachingAssignment.isApproved() == false || (teachingAssignment.isBuyout() == false && teachingAssignment.isWorkLifeBalance() == false)) {
-            return;
-        }
-
-        LineItem lineItemDTO = new LineItem();
-        lineItemDTO.setAmount(new BigDecimal(0));
-        lineItemDTO.setBudgetScenario(budgetScenario);
-
-        String description = "";
-
-        if (teachingAssignment.isBuyout()) {
-            lineItemDTO.setLineItemCategory(lineItemCategoryService.findByDescription("Buyout Lecturer Replacement Funds"));
-            description = teachingAssignment.getInstructor().getFullName() + " Buyout Funds for " + Term.getRegistrarName(teachingAssignment.getTermCode());
-        } else if (teachingAssignment.isWorkLifeBalance()) {
-            lineItemDTO.setLineItemCategory(lineItemCategoryService.findByDescription("Work-Life Balance Funds"));
-            description = teachingAssignment.getInstructor().getFullName() + " Work-Life Balance Funds for " + Term.getRegistrarName(teachingAssignment.getTermCode());
-        }
-
-        lineItemDTO.setDescription(description);
-
-        this.findOrCreate(lineItemDTO);
-    }
 }

--- a/src/main/resources/db/migration/V186__Add_hidden_to_lineItems.sql
+++ b/src/main/resources/db/migration/V186__Add_hidden_to_lineItems.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `LineItems` ADD COLUMN `Hidden` Boolean NOT NULL DEFAULT false;

--- a/src/main/resources/db/migration/V187__Add_teachingAssignments_to_lineItems.sql
+++ b/src/main/resources/db/migration/V187__Add_teachingAssignments_to_lineItems.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `LineItems` ADD COLUMN `TeachingAssignmentId` int(11) NULL;


### PR DESCRIPTION
Significantly changes line item behavior:
- Previously line items were automatically created and synced to buyouts/work-life balance assignments. These have been removed (unless the user modified them)
- Now, the buyout/work-life balance based lineItems will be calculated and displayed on page load
- If a user edits them, they will become persisted.
- If the buyout is removed, a warning will be displayed
- If one of this implicit line items is deleted, it will instead be 'hidden', and no longer affect calculations.
- A filter option to show hidden line items is now available, with the option to restore hidden line items.

Issue:
https://trello.com/c/Z830Rfpl/1536-line-items-should-be-live-not-generated