### PR TITLE
Bugfix/email notifications not sending

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/entities/Schedule.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/Schedule.java
@@ -2,6 +2,7 @@ package edu.ucdavis.dss.ipa.entities;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -264,5 +265,19 @@ public class Schedule implements Serializable {
 			}
 		}
 		return terms;
+	}
+
+	/**
+	 * 	Returns false if the 'ending year' of the academic year range has been passed.
+	 * 	Example: for schedule with year 2016 (academic year 2016-17, it will return true once the currentYear is 2018.
+	 * @return
+     */
+	@Transient
+	@JsonIgnore
+	public boolean isHistorical() {
+		Calendar now = Calendar.getInstance();
+		int currentYear = now.get(Calendar.YEAR);
+
+		return currentYear <= (this.getYear() + 1);
 	}
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/Schedule.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/Schedule.java
@@ -278,6 +278,6 @@ public class Schedule implements Serializable {
 		Calendar now = Calendar.getInstance();
 		int currentYear = now.get(Calendar.YEAR);
 
-		return currentYear <= (this.getYear() + 1);
+		return currentYear > (this.getYear() + 1);
 	}
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaInstructorSupportCallResponseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaInstructorSupportCallResponseService.java
@@ -88,7 +88,7 @@ public class JpaInstructorSupportCallResponseService implements InstructorSuppor
 
         for (Schedule schedule : workgroup.getSchedules()) {
             // Ignore historical schedules
-            if (schedule.getYear() >= currentYear) {
+            if (schedule.isHistorical() == false) {
 
                 // Check teachingCallReceipts to see if messages need to be sent
                 for (InstructorSupportCallResponse instructorSupportCallResponse : schedule.getInstructorSupportCallResponses()) {

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaStudentSupportCallResponseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaStudentSupportCallResponseService.java
@@ -101,7 +101,7 @@ public class JpaStudentSupportCallResponseService implements StudentSupportCallR
 
         for (Schedule schedule : workgroup.getSchedules()) {
             // Ignore historical schedules
-            if (currentYear <= (schedule.getYear() + 1)) {
+            if (schedule.isHistorical() == false) {
 
                 // Check teachingCallReceipts to see if messages need to be sent
                 for (StudentSupportCallResponse studentSupportCallResponse : schedule.getStudentSupportCallResponses()) {

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaStudentSupportCallResponseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaStudentSupportCallResponseService.java
@@ -101,7 +101,7 @@ public class JpaStudentSupportCallResponseService implements StudentSupportCallR
 
         for (Schedule schedule : workgroup.getSchedules()) {
             // Ignore historical schedules
-            if (schedule.getYear() >= currentYear) {
+            if (currentYear <= (schedule.getYear() + 1)) {
 
                 // Check teachingCallReceipts to see if messages need to be sent
                 for (StudentSupportCallResponse studentSupportCallResponse : schedule.getStudentSupportCallResponses()) {

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
@@ -71,9 +71,7 @@ public class JpaTeachingCallReceiptService implements TeachingCallReceiptService
 
 		for (Schedule schedule : workgroup.getSchedules()) {
 			// Only check non-historical schedules
-			// Ensure the 'ending year' of the academic year range has been passed.
-			// Example: for schedule with year 2016 (academic year 2016-17, ensure that the currentYear is greater than 2017 before simply ignoring the schedule entirely.
-			if (currentYear <= (schedule.getYear() + 1)) {
+			if (schedule.isHistorical() == false) {
 				// Check teachingCallReceipts to see if messages need to be sent
 				for (TeachingCallReceipt teachingCallReceipt : schedule.getTeachingCallReceipts()) {
 					// Send scheduled email if the send date has been passed


### PR DESCRIPTION
Fixes bug in email send notification processing, was incorrectly identifying a year as historical during Spring term.

Issue:
https://trello.com/c/z3vgc7y6/1591-support-call-emails-not-sending