### PR TITLE
CoursesView: Should not assume sectionGroup exists

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
@@ -108,8 +108,14 @@ public class CourseViewController {
 
 	@RequestMapping(value = "/api/courseView/sectionGroups/{sectionGroupId}", method = RequestMethod.PUT, produces="application/json")
 	@ResponseBody
-	public SectionGroup updateSectionGroup(@PathVariable long sectionGroupId, @RequestBody SectionGroup sectionGroup) {
+	public SectionGroup updateSectionGroup(@PathVariable long sectionGroupId, @RequestBody SectionGroup sectionGroup, HttpServletResponse httpResponse) {
 		SectionGroup originalSectionGroup = sectionGroupService.getOneById(sectionGroupId);
+
+		if (originalSectionGroup == null) {
+			httpResponse.setStatus(HttpStatus.NOT_FOUND.value());
+			return null;
+		}
+
 		Workgroup workgroup = originalSectionGroup.getCourse().getSchedule().getWorkgroup();
 		authorizer.hasWorkgroupRole(workgroup.getId(), "academicPlanner");
 


### PR DESCRIPTION
If a sectionGroup is deleted by another user, attempting to set planned seats on that sectionGroup will trigger an error.

Issue:
https://trello.com/c/GJxYtuix/1575-null-pointer-exception-on-courseviewcontrollerupdatesectiongroup