### PR TITLE
Fix database rows with null schedule review flags

### DIFF
--- a/src/main/resources/db/migration/V189__Migrate_empty_schedule_review.sql
+++ b/src/main/resources/db/migration/V189__Migrate_empty_schedule_review.sql
@@ -1,0 +1,2 @@
+UPDATE `Schedules` SET `SupportStaffSupportCallReviewOpen` = "0000000000" WHERE `SupportStaffSupportCallReviewOpen` IS NULL;
+UPDATE `Schedules` SET `InstructorSupportCallReviewOpen` = "0000000000" WHERE `InstructorSupportCallReviewOpen` IS NULL;


### PR DESCRIPTION
Issue:
https://trello.com/c/SIZsld8P/1629-supportassignments-error-on-page-load

This issue was being caused by schedules with null review bitfields.

At some point in the past schedules were being created with a null value for the review bitfields, and attempting to load the supportAssignments page for these schedules would cause an error.

The proper validations on the schedule entity are already in place, and new schedules are getting the proper defaults currently, just needed to fix the old data.