### PR TITLE
Adjustments to allow tasks to run in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ipa-web.env
 certs/
 out/
 *.log
+bin/

--- a/src/main/java/edu/ucdavis/dss/dw/DwClient.java
+++ b/src/main/java/edu/ucdavis/dss/dw/DwClient.java
@@ -226,54 +226,30 @@ public class DwClient {
 		return dwPerson;
 	}
 
-	public DwCourse searchCourses(String subjectCode, String courseNumber, String effectiveTermCode) throws IOException {
-		String query = subjectCode + " " + courseNumber;
+	/**
+	 * Finds a course in DW with the given subjectCode, courseNumber, and effectiveTermCode
+	 *
+	 * @param subjectCode e.g. ECS, PHY
+	 * @param courseNumber e.g. 101, 10A, 010
+	 * @param effectiveTermCode e.g. 200410
+	 * @return a DwCourse representing the found course or null if no course found
+	 * @throws IOException
+	 */
+	public DwCourse findCourse(String subjectCode, String courseNumber, String effectiveTermCode) throws IOException {
+		List<DwCourse> dwCourses = this.searchCourses(subjectCode + " " + courseNumber);
 
-		DwCourse dwCourse = new DwCourse();
-		List<DwCourse> dwCourses = null;
-
-		if (connect() && query != null) {
-			HttpGet httpget = new HttpGet("/courses/search?q=" + URLEncoder.encode(query, "UTF-8") + "&token=" + ApiToken);
-
-			CloseableHttpResponse response = httpclient.execute(
-					targetHost, httpget, context);
-
-			StatusLine line = response.getStatusLine();
-			if(line.getStatusCode() != 200) {
-				throw new IllegalStateException("Data Warehouse did not return a 200 OK (was " + line.getStatusCode() + "). URL: /courses/search?q=" + URLEncoder.encode(query, "UTF-8"));
-			}
-
-			HttpEntity entity = response.getEntity();
-
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode arrNode = new ObjectMapper().readTree(EntityUtils.toString(entity));
-			if (arrNode != null) {
-				dwCourses = mapper.readValue(
-						arrNode.toString(),
-						mapper.getTypeFactory().constructCollectionType(
-								List.class, DwCourse.class));
-			} else {
-				log.warn("searchUsers Response from DW returned null, for criterion = " + query);
-			}
-
-			response.close();
-		} else if (query == null) {
-			log.warn("No query given.");
-		}
-
-		for ( DwCourse slotDwCourse : dwCourses) {
-			if (slotDwCourse.getCourseNumber().equals(courseNumber)
-					&& slotDwCourse.getSubjectCode().equals(subjectCode)
-					&& slotDwCourse.getEffectiveTermCode().equals(effectiveTermCode)) {
-				return slotDwCourse;
+		for (DwCourse dwCourse : dwCourses) {
+			if (dwCourse.getCourseNumber().equals(courseNumber)
+					&& dwCourse.getSubjectCode().equals(subjectCode)
+					&& dwCourse.getEffectiveTermCode().equals(effectiveTermCode)) {
+				return dwCourse;
 			}
 		}
-		return dwCourse;
 
+		return null;
 	}
 
-	public List<DwCourse> queryCourses(String query) throws ClientProtocolException, IOException {
-		DwCourse dwCourse = new DwCourse();
+	public List<DwCourse> searchCourses(String query) throws IOException {
 		List<DwCourse> dwCourses = null;
 
 		if (connect() && query != null) {

--- a/src/main/java/edu/ucdavis/dss/dw/dto/DwCourse.java
+++ b/src/main/java/edu/ucdavis/dss/dw/dto/DwCourse.java
@@ -4,12 +4,8 @@ package edu.ucdavis.dss.dw.dto;
  * Created by Lloyd on 10/4/16.
  */
 public class DwCourse {
-    String subjectCode;
-    String effectiveTermCode;
-    String title;
-    String courseNumber;
-    long creditHoursLow;
-    long creditHoursHigh;
+    String subjectCode, effectiveTermCode, title, courseNumber;
+    Float creditHoursLow, creditHoursHigh;
 
     public String getCourseNumber() {
         return courseNumber;
@@ -43,19 +39,19 @@ public class DwCourse {
         this.title = title;
     }
 
-    public long getCreditHoursLow() {
+    public Float getCreditHoursLow() {
         return creditHoursLow;
     }
 
-    public void setCreditHoursLow(long creditHoursLow) {
+    public void setCreditHoursLow(Float creditHoursLow) {
         this.creditHoursLow = creditHoursLow;
     }
 
-    public long getCreditHoursHigh() {
+    public Float getCreditHoursHigh() {
         return creditHoursHigh;
     }
 
-    public void setCreditHoursHigh(long creditHoursHigh) {
+    public void setCreditHoursHigh(Float creditHoursHigh) {
         this.creditHoursHigh = creditHoursHigh;
     }
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -24,9 +24,7 @@ public class AssignmentViewTeachingAssignmentController {
     @Inject InstructorService instructorService;
     @Inject DataWarehouseRepository dwRepository;
     @Inject Authorizer authorizer;
-    @Inject BudgetScenarioService budgetScenarioService;
     @Inject InstructorTypeService instructorTypeService;
-    @Inject UserRoleService userRoleService;
 
     @RequestMapping(value = "/api/assignmentView/schedules/{scheduleId}/teachingAssignments", method = RequestMethod.POST, produces="application/json")
     @ResponseBody
@@ -184,13 +182,14 @@ public class AssignmentViewTeachingAssignmentController {
             } else {
                 // Necessary course was not found, need to create it
                 Course course = new Course();
+
                 course.setCourseNumber(teachingAssignment.getSuggestedCourseNumber());
                 course.setSchedule(schedule);
                 course.setEffectiveTermCode(teachingAssignment.getSuggestedEffectiveTermCode());
                 course.setSubjectCode(teachingAssignment.getSuggestedSubjectCode());
                 course.setSequencePattern("001");
 
-                DwCourse dwCourse = dwRepository.searchCourses(teachingAssignment.getSuggestedSubjectCode(), teachingAssignment.getSuggestedCourseNumber(), teachingAssignment.getSuggestedEffectiveTermCode());
+                DwCourse dwCourse = dwRepository.findCourse(teachingAssignment.getSuggestedSubjectCode(), teachingAssignment.getSuggestedCourseNumber(), teachingAssignment.getSuggestedEffectiveTermCode());
                 if (dwCourse != null && dwCourse.getTitle() != null) {
                     course.setTitle(dwCourse.getTitle());
                 } else {
@@ -217,6 +216,7 @@ public class AssignmentViewTeachingAssignmentController {
             originalTeachingAssignment.setSuggestedSubjectCode(null);
             originalTeachingAssignment.setSuggestedCourseNumber(null);
             originalTeachingAssignment.setApproved(teachingAssignment.isApproved());
+
             teachingAssignmentService.saveAndAddInstructorType(originalTeachingAssignment);
 
             originalTeachingAssignment.setSuggestedCourseNumber(teachingAssignment.getSuggestedCourseNumber());

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/course/CourseViewController.java
@@ -455,17 +455,6 @@ public class CourseViewController {
 
 					Term term = termHashMap.get(newTermCode);
 
-					Long unitsHigh = 0L;
-					Long unitsLow = 0L;
-
-					if (sectionGroupImport.getUnitsHigh() != null) {
-						unitsHigh = Long.valueOf(sectionGroupImport.getUnitsHigh());
-					}
-
-					if (sectionGroupImport.getUnitsLow() != null) {
-						unitsLow = Long.valueOf(sectionGroupImport.getUnitsLow());
-					}
-
 					Course courseDTO = new Course();
 					courseDTO.setSubjectCode(sectionGroupImport.getSubjectCode());
 					courseDTO.setCourseNumber(sectionGroupImport.getCourseNumber());
@@ -473,8 +462,18 @@ public class CourseViewController {
 					courseDTO.setTitle(sectionGroupImport.getTitle());
 					courseDTO.setEffectiveTermCode(sectionGroupImport.getEffectiveTermCode());
 					courseDTO.setSchedule(schedule);
-					courseDTO.setUnitsHigh(unitsHigh);
-					courseDTO.setUnitsLow(unitsLow);
+
+					Float unitsHigh, unitsLow;
+
+					if (sectionGroupImport.getUnitsHigh() != null) {
+						unitsHigh = Float.valueOf(sectionGroupImport.getUnitsHigh());
+						courseDTO.setUnitsHigh(unitsHigh);
+					}
+
+					if (sectionGroupImport.getUnitsLow() != null) {
+						unitsLow = Float.valueOf(sectionGroupImport.getUnitsLow());
+						courseDTO.setUnitsLow(unitsLow);
+					}
 
 					Course course = courseService.findOrCreateByCourse(courseDTO);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/Course.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/Course.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 public class Course extends BaseEntity {
 	private long id;
 	private String title, subjectCode, courseNumber, effectiveTermCode, sequencePattern;
-	private float unitsLow, unitsHigh;
+	private Float unitsLow, unitsHigh;
 	private Schedule schedule;
 	private List<SectionGroup> sectionGroups = new ArrayList<>();
 	private List<Tag> tags = new ArrayList<Tag>(0);
@@ -113,22 +113,22 @@ public class Course extends BaseEntity {
 	@Basic
 	@Column(name = "UnitsLow", nullable = true)
 	@JsonProperty
-	public float getUnitsLow() {
+	public Float getUnitsLow() {
 		return unitsLow;
 	}
 
-	public void setUnitsLow(float unitsLow) {
+	public void setUnitsLow(Float unitsLow) {
 		this.unitsLow = unitsLow;
 	}
 
 	@Basic
 	@Column(name = "UnitsHigh", nullable = true)
 	@JsonProperty
-	public float getUnitsHigh() {
+	public Float getUnitsHigh() {
 		return unitsHigh;
 	}
 
-	public void setUnitsHigh(float unitsHigh) {
+	public void setUnitsHigh(Float unitsHigh) {
 		this.unitsHigh = unitsHigh;
 	}
 

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/CourseRepository.java
@@ -64,12 +64,5 @@ public interface CourseRepository extends CrudRepository<Course, Long> {
 
     Course findOneBySubjectCodeAndCourseNumberAndSequencePatternAndScheduleId(String subjectCode, String courseNumber, String sequencePattern, long scheduleId);
 
-    /**
-     * Delete all Courses with ids specified in {@code ids} parameter
-     *
-     * @param courseIds List of user ids
-     */
-    @Modifying
-    @Query("delete from Course c where c.id in ?1")
-    void deleteCoursesWithIds(List<Long> courseIds);
+    List<Course> findByUnitsLow(Float unitsLow);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/DataWarehouseRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/DataWarehouseRepository.java
@@ -22,9 +22,9 @@ public interface DataWarehouseRepository {
 
 	DwPerson getPersonByLoginId(String loginId);
 
-	DwCourse searchCourses(String suggestedSubjectCode, String suggestedCourseNumber, String suggestedEffectiveTermCode);
+	DwCourse findCourse(String suggestedSubjectCode, String suggestedCourseNumber, String suggestedEffectiveTermCode);
 
-	List<DwCourse> queryCourses(String query);
+	List<DwCourse> searchCourses(String query);
 
 	List<DwSection> getSectionsByTermCodeAndUniqueKeys(String termCode, List<String> uniqueKeys);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/RestDataWarehouseRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/RestDataWarehouseRepository.java
@@ -36,7 +36,7 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 	 * @return
      */
 	public List<DwPerson> searchPeople(String query) {
-		DwClient dwClient = null;
+		DwClient dwClient;
 
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
@@ -53,7 +53,7 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 	 * @return a list of DwTerms
 	 */
 	public List<DwTerm> getTerms() {
-		DwClient dwClient = null;
+		DwClient dwClient;
 
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
@@ -72,7 +72,7 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 	 * @return
 	 */
 	public DwPerson getPersonByLoginId(String loginId) {
-		DwClient dwClient = null;
+		DwClient dwClient;
 
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
@@ -85,12 +85,13 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 	}
 
 	@Override
-	public DwCourse searchCourses(String subjectCode, String courseNumber, String effectiveTermCode) {
-		DwClient dwClient = null;
+	public DwCourse findCourse(String subjectCode, String courseNumber, String effectiveTermCode) {
+		DwClient dwClient;
+
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
 
-			return dwClient.searchCourses(subjectCode, courseNumber, effectiveTermCode);
+			return dwClient.findCourse(subjectCode, courseNumber, effectiveTermCode);
 		} catch (Exception e) {
 			emailService.reportException(e, this.getClass().getName());
 			return null;
@@ -98,22 +99,23 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 	}
 
 	@Override
-	public List<DwCourse> queryCourses(String query) {
-		DwClient dwClient = null;
+	public List<DwCourse> searchCourses(String query) {
+		DwClient dwClient;
+
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
 
-			return dwClient.queryCourses(query);
+			return dwClient.searchCourses(query);
 		} catch (Exception e) {
 			emailService.reportException(e, this.getClass().getName());
 			return null;
 		}
 	}
-
 
 	@Override
 	public List<DwSection> getSectionsByTermCodeAndUniqueKeys(String termCode, List<String> uniqueKeys) {
-		DwClient dwClient = null;
+		DwClient dwClient;
+
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
 
@@ -140,7 +142,8 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 
 	@Override
 	public List<DwSection> getSectionsBySubjectCodeAndYear(String subjectCode, Long year) {
-		DwClient dwClient = null;
+		DwClient dwClient;
+
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
 
@@ -155,7 +158,8 @@ public class RestDataWarehouseRepository implements DataWarehouseRepository {
 
 	@Override
 	public List<DwSection> getSectionsBySubjectCodeAndTermCode(String subjectCode, String termCode) {
-		DwClient dwClient = null;
+		DwClient dwClient;
+
 		try {
 			dwClient = new DwClient(dwUrl, dwToken, dwPort);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/CourseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/CourseService.java
@@ -20,21 +20,16 @@ public interface CourseService {
 
 	Course removeTag(Course course, Tag tag);
 
-	List<Course> findByTagId(Long id);
-
 	List<Course> findByWorkgroupIdAndYear(long workgroupId, long year);
 
 	List<Course> findVisibleByWorkgroupIdAndYear(long id, long year);
 
 	List<Course> findBySubjectCodeAndCourseNumberAndScheduleId(String subjectCode, String courseNumber, long id);
 
+	List<Course> findByUnitsLow(Float unitsLow);
+
 	Course findOrCreateBySubjectCodeAndCourseNumberAndSequencePatternAndTitleAndEffectiveTermCodeAndScheduleId(
 			String subjectCode, String courseNumber, String sequencePattern, String title, String effectiveTermCode, Schedule schedule, boolean copyMetaData);
-
-	Course createBySubjectCodeAndCourseNumberAndSequencePatternAndTitleAndEffectiveTermCodeAndScheduleId(
-			String subjectCode, String courseNumber, String sequencePattern, String title, String effectiveTermCode, Schedule schedule, boolean copyMetaData);
-
-	Course copyMetaDataAndAddToSchedule(Course course, Schedule schedule);
 
 	Course create(Course course);
 
@@ -42,7 +37,7 @@ public interface CourseService {
 
 	List<Course> getAllCourses();
 
-	Course syncUnits(Course course);
+	Course updateUnits(Course course, Float unitsLow, Float unitsHigh);
 
 	Course findOrCreateByCourse(Course courseDTO);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaScheduleOpsService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaScheduleOpsService.java
@@ -221,7 +221,6 @@ public class JpaScheduleOpsService implements ScheduleOpsService {
 							if (sectionService.hasValidSequenceNumber(section)) {
 								section = this.sectionService.save(section);
 							}
-
 						}
 
 						activityService.syncActivityLocations(dwSection, section.getActivities());

--- a/src/main/java/edu/ucdavis/dss/ipa/tasks/EmailNotificationTask.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/tasks/EmailNotificationTask.java
@@ -22,8 +22,9 @@ import edu.ucdavis.dss.ipa.services.WorkgroupService;
  *
  */
 @Service
-@Profile({"production", "staging"})
+@Profile({"production", "staging", "development"})
 public class EmailNotificationTask {
+	final long FIVE_MINUTES_IN_MILLISECONDS = 300000;
 	private final Logger log = LoggerFactory.getLogger("EmailNotificationTask");
 
 	@Inject WorkgroupService workgroupService;
@@ -33,7 +34,7 @@ public class EmailNotificationTask {
 
 	private static boolean runningTask = false; /* flag to avoid multiple concurrent tasks */
 
-	@Scheduled( fixedDelay = 300000 ) // Every 5 minutes
+	@Scheduled( fixedDelay = FIVE_MINUTES_IN_MILLISECONDS )
 	@Async
 	public void scanForEmailsToSend() {
 		if(runningTask) {
@@ -56,5 +57,4 @@ public class EmailNotificationTask {
 
 		log.debug("scanForEmailsToSend() finished");
 	}
-
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/tasks/TermUpdateTask.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/tasks/TermUpdateTask.java
@@ -4,6 +4,8 @@ import edu.ucdavis.dss.dw.dto.DwTerm;
 import edu.ucdavis.dss.ipa.entities.Term;
 import edu.ucdavis.dss.ipa.repositories.DataWarehouseRepository;
 import edu.ucdavis.dss.ipa.services.TermService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -19,13 +21,13 @@ import java.util.List;
 import java.util.Locale;
 
 @Service
-@Profile({"production", "staging"})
+@Profile({"production", "staging", "development"})
 public class TermUpdateTask {
+    final long HALF_DAY_IN_MILLISECONDS = 43200000;
     private static boolean runningTask = false; /* flag to avoid multiple concurrent tasks */
+    private final Logger log = LoggerFactory.getLogger("TermUpdateTask");
 
-    @Inject
-    DataWarehouseRepository dataWarehouseRepository;
-
+    @Inject DataWarehouseRepository dataWarehouseRepository;
     @Inject TermService termService;
 
     /**
@@ -33,18 +35,19 @@ public class TermUpdateTask {
      * 'Terms' table with term start/end dates. This is needed to lock
      * schedules, etc.
      */
-    @Scheduled( fixedDelay = 43200000 ) // every 12 hours
+    @Scheduled( fixedDelay = HALF_DAY_IN_MILLISECONDS )
     @Async
     public void updateTermsFromDW() {
         if(runningTask) return; // avoid multiple concurrent jobs
         runningTask = true;
 
+        log.debug("updateTermsFromDW() started");
+
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
 
         List<DwTerm> dwTerms = dataWarehouseRepository.getTerms();
 
-        // Loop through DW terms and update our local terms, creating them
-        // if necessary.
+        // Loop through DW terms and update our local terms, creating them if necessary.
         for(DwTerm dwTerm : dwTerms) {
             Term localTerm = this.termService.getOneByTermCode(dwTerm.getCode());
 
@@ -79,7 +82,8 @@ public class TermUpdateTask {
             this.termService.save(localTerm);
         }
 
+        log.debug("updateTermsFromDW() finished");
+
         runningTask = false;
     }
-
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/tasks/UpdateCourseTask.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/tasks/UpdateCourseTask.java
@@ -5,6 +5,8 @@ import edu.ucdavis.dss.ipa.entities.Course;
 import edu.ucdavis.dss.ipa.repositories.DataWarehouseRepository;
 import edu.ucdavis.dss.ipa.services.ActivityService;
 import edu.ucdavis.dss.ipa.services.CourseService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,57 +16,41 @@ import javax.inject.Inject;
 import java.util.*;
 
 @Service
-@Profile({"production", "staging"})
+@Profile({"production", "staging", "development"})
 public class UpdateCourseTask {
+    final long ONE_DAY_IN_MILLISECONDS = 86400000;
     private static boolean runningTask = false; /* flag to avoid multiple concurrent tasks */
+    private final Logger log = LoggerFactory.getLogger("UpdateCourseTask");
 
-    @Inject
-    DataWarehouseRepository dataWarehouseRepository;
+    @Inject DataWarehouseRepository dataWarehouseRepository;
     @Inject CourseService courseService;
-    @Inject ActivityService activityService;
 
     /**
-     * Finds Courses with zero units and Queries Data Warehouse for term information and updates the local
+     * Finds courses with null units low (should not happen) and queries for updates
      */
-    @Scheduled( fixedDelay = 86400000 ) // every 24 hours
+    @Scheduled( fixedDelay = ONE_DAY_IN_MILLISECONDS )
     @Async
-    public void updateCourseTaskFromDW() {
+    public void updateCoursesFromDW() {
+        int numCoursesUpdated = 0;
 
         if(runningTask) return; // avoid multiple concurrent jobs
         runningTask = true;
 
+        log.debug("updateCoursesFromDW() started");
+
         // Update Courses to have the proper units value
-        List<Course> courses = this.courseService.getAllCourses();
-        Map<String, List<DwCourse>> allDwCourses = new HashMap<>();
+        List<Course> courses = this.courseService.findByUnitsLow(null);
 
         for (Course course : courses) {
-            // Only interested in courses with 0 units
-            if (course.getUnitsLow() != 0 || course.getUnitsHigh() != 0) {
-                continue;
-            }
+            DwCourse dwCourse = dataWarehouseRepository.findCourse(course.getSubjectCode(), course.getCourseNumber(), course.getEffectiveTermCode());
 
-            // Query DW for courses of this subject code, if necessary
-            String subjectCode = course.getSubjectCode();
-            if (allDwCourses.get(subjectCode) == null) {
-                List<DwCourse> dwCourses = dataWarehouseRepository.queryCourses(subjectCode);
-                allDwCourses.put(subjectCode, dwCourses);
-            }
-
-            for (DwCourse dwCourse : allDwCourses.get(subjectCode)) {
-
-                // Identify IPA course that matches this dwCourse
-                if (dwCourse.getSubjectCode().equals(course.getSubjectCode())
-                && dwCourse.getCourseNumber().equals(course.getCourseNumber())) {
-
-                    // Attempt to fill in course units
-                    if (dwCourse.getCreditHoursHigh() != 0 || dwCourse.getCreditHoursLow() != 0) {
-                        course.setUnitsHigh(dwCourse.getCreditHoursHigh());
-                        course.setUnitsLow(dwCourse.getCreditHoursLow());
-                        courseService.syncUnits(course);
-                    }
-                }
+            if (dwCourse != null) {
+                courseService.updateUnits(course, dwCourse.getCreditHoursLow(), dwCourse.getCreditHoursHigh());
+                numCoursesUpdated++;
             }
         }
+
+        log.debug("updateCoursesFromDW() finished. Updated " + numCoursesUpdated + " courses");
 
         runningTask = false;
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/tasks/UpdateSectionsTask.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/tasks/UpdateSectionsTask.java
@@ -12,8 +12,9 @@ import javax.inject.Inject;
 import java.util.*;
 
 @Service
-@Profile({"production", "staging"})
+@Profile({"production", "staging", "development"})
 public class UpdateSectionsTask {
+    final long ONE_DAY_IN_MILLISECONDS = 86400000;
     private static boolean runningTask = false; /* flag to avoid multiple concurrent tasks */
     private static final Logger log = LoggerFactory.getLogger("UpdateSectionsTask");
 
@@ -22,12 +23,13 @@ public class UpdateSectionsTask {
     /**
      * Syncs CRN and location data from DW to IPA, assuming the section/activities already exist
      */
-    @Scheduled( fixedDelay = 86400000 ) // every 24 hours
+    @Scheduled( fixedDelay = ONE_DAY_IN_MILLISECONDS )
     @Async
-    public void updateSectionsTaskFromDW() {
-
+    public void updateSectionsFromDW() {
         if(runningTask) return; // avoid multiple concurrent jobs
         runningTask = true;
+
+        log.debug("updateSectionsFromDW() started");
 
         this.scheduleOpsService.updateSectionsFromDW();
         try {
@@ -36,6 +38,8 @@ public class UpdateSectionsTask {
             log.error("TransactionSystemException while updating empty section groups!");
             log.error(e.toString());
         }
+
+        log.debug("updateSectionsFromDW() finished");
 
         runningTask = false;
     }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -32,6 +32,8 @@
     <logger name="UpdateUsersTask" level="DEBUG" />
     <logger name="EmailNotificationTask" level="DEBUG" />
     <logger name="UpdateSectionsTask" level="DEBUG" />
+    <logger name="TermUpdateTask" level="DEBUG" />
+    <logger name="UpdateCourseTask" level="DEBUG" />
     
     <logger name="EmailUtility" level="INFO">
         <appender-ref ref="FILE" />

--- a/src/test/java/edu/ucdavis/dss/ipa/repositories/MockDataWarehouseRepository.java
+++ b/src/test/java/edu/ucdavis/dss/ipa/repositories/MockDataWarehouseRepository.java
@@ -44,15 +44,14 @@ public class MockDataWarehouseRepository implements DataWarehouseRepository {
     }
 
     @Override
-    public DwCourse searchCourses(String subjectCode, String courseNumber, String effectiveTermCode) {
+    public DwCourse findCourse(String subjectCode, String courseNumber, String effectiveTermCode) {
         return null;
     }
 
     @Override
-    public List<DwCourse> queryCourses(String query) {
+    public List<DwCourse> searchCourses(String query) {
         return null;
     }
-
 
     @Override
     public List<DwSection> getSectionsByTermCodeAndUniqueKeys(String termCode, List<String> uniqueKeys) {


### PR DESCRIPTION
This PR is motivated by a desire to run background tasks in development in order to catch bugs during development.

In practice, we have had background tasks fail in production and go unnoticed.

One concern with running these tasks in development is the sending of e-mails, but this concern is mitigated as the ConsoleEmailService (a non-SMTP client) is used in development.

Changes:

- DwClient/DataWarehouseRepository searchCourses() has been renamed findCourse() given that it only returns one result. It also correctly returns null now instead of a blank DwCourse DTO.
- DwClient/DataWarehouseRepository queryCourses() was renamed searchCourses() to improve the language
- Credit hours (units) low and high have been changed to Float from float given that they are nullable in both our database and Banner
- The update units task now only searches for courses with units low = zero, as only this condition implies missing units. Units high can be null in Banner.
- Minor syntax changes and cleanups