### PR TITLE
Teaching Call Improvements

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/teachingCall/TeachingCallStatusViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/teachingCall/TeachingCallStatusViewController.java
@@ -158,7 +158,7 @@ public class TeachingCallStatusViewController {
             receiptDTO.setNextContactAt(now);
         }
 
-        List<TeachingCallReceipt> teachingCallReceipts = teachingCallReceiptService.createMany(addInstructorsDTO.getInstructorIds(), receiptDTO);
+        List<TeachingCallReceipt> teachingCallReceipts = teachingCallReceiptService.createOrUpdateMany(addInstructorsDTO.getInstructorIds(), receiptDTO);
 
         return teachingCallReceipts;
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/TeachingCallReceiptRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/TeachingCallReceiptRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface TeachingCallReceiptRepository extends CrudRepository<TeachingCallReceipt, Long> {
 
+  TeachingCallReceipt findByInstructorIdAndScheduleId(Long instructorId, long scheduleId);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/TeachingCallReceiptService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/TeachingCallReceiptService.java
@@ -21,7 +21,7 @@ public interface TeachingCallReceiptService {
 
 	TeachingCallReceipt create(TeachingCallReceipt teachingCallReceipt);
 
-	List<TeachingCallReceipt> createMany(List<Long> instructorIds, TeachingCallReceipt teachingCallReceipt);
+	List<TeachingCallReceipt> createOrUpdateMany(List<Long> instructorIds, TeachingCallReceipt teachingCallReceipt);
 
 	boolean delete(Long id);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
@@ -231,28 +231,37 @@ public class JpaTeachingCallReceiptService implements TeachingCallReceiptService
 	}
 
 	@Override
-	public List<TeachingCallReceipt> createMany(List<Long> instructorIds, TeachingCallReceipt teachingCallReceiptDTO) {
+	public List<TeachingCallReceipt> createOrUpdateMany(List<Long> instructorIds, TeachingCallReceipt teachingCallReceiptDTO) {
 		List<TeachingCallReceipt> receipts = new ArrayList<>();
 
 		for (Long instructorId : instructorIds) {
+			TeachingCallReceipt teachingCallReceipt = this.findByInstructorIdAndScheduleId(instructorId, teachingCallReceiptDTO.getSchedule().getId());
+
+			if (teachingCallReceipt == null) {
+				teachingCallReceipt = new TeachingCallReceipt();
+			}
+
 			Instructor slotInstructor = instructorService.getOneById(instructorId);
-			TeachingCallReceipt slotTeachingCallReceipt = new TeachingCallReceipt();
 
-			slotTeachingCallReceipt.setSchedule(teachingCallReceiptDTO.getSchedule());
-			slotTeachingCallReceipt.setInstructor(slotInstructor);
-			slotTeachingCallReceipt.setIsDone(false);
-			slotTeachingCallReceipt.setMessage(teachingCallReceiptDTO.getMessage());
-			slotTeachingCallReceipt.setNextContactAt(teachingCallReceiptDTO.getNextContactAt());
-			slotTeachingCallReceipt.setShowUnavailabilities(teachingCallReceiptDTO.getShowUnavailabilities());
-			slotTeachingCallReceipt.setTermsBlob(teachingCallReceiptDTO.getTermsBlob());
-			slotTeachingCallReceipt.setDueDate(teachingCallReceiptDTO.getDueDate());
+			teachingCallReceipt.setSchedule(teachingCallReceiptDTO.getSchedule());
+			teachingCallReceipt.setInstructor(slotInstructor);
+			teachingCallReceipt.setIsDone(false);
+			teachingCallReceipt.setMessage(teachingCallReceiptDTO.getMessage());
+			teachingCallReceipt.setNextContactAt(teachingCallReceiptDTO.getNextContactAt());
+			teachingCallReceipt.setShowUnavailabilities(teachingCallReceiptDTO.getShowUnavailabilities());
+			teachingCallReceipt.setTermsBlob(teachingCallReceiptDTO.getTermsBlob());
+			teachingCallReceipt.setDueDate(teachingCallReceiptDTO.getDueDate());
 
-			slotTeachingCallReceipt = this.save(slotTeachingCallReceipt);
+			teachingCallReceipt = this.save(teachingCallReceipt);
 
-			receipts.add(slotTeachingCallReceipt);
+			receipts.add(teachingCallReceipt);
 		}
 
 		return receipts;
+	}
+
+	private TeachingCallReceipt findByInstructorIdAndScheduleId(Long instructorId, long scheduleId) {
+		return this.teachingCallReceiptRepository.findByInstructorIdAndScheduleId(instructorId, scheduleId);
 	}
 
 	@Override

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
@@ -239,12 +239,12 @@ public class JpaTeachingCallReceiptService implements TeachingCallReceiptService
 
 			if (teachingCallReceipt == null) {
 				teachingCallReceipt = new TeachingCallReceipt();
+				Instructor slotInstructor = instructorService.getOneById(instructorId);
+
+				teachingCallReceipt.setSchedule(teachingCallReceiptDTO.getSchedule());
+				teachingCallReceipt.setInstructor(slotInstructor);
 			}
 
-			Instructor slotInstructor = instructorService.getOneById(instructorId);
-
-			teachingCallReceipt.setSchedule(teachingCallReceiptDTO.getSchedule());
-			teachingCallReceipt.setInstructor(slotInstructor);
 			teachingCallReceipt.setIsDone(false);
 			teachingCallReceipt.setMessage(teachingCallReceiptDTO.getMessage());
 			teachingCallReceipt.setNextContactAt(teachingCallReceiptDTO.getNextContactAt());


### PR DESCRIPTION
Adds the following improvements:
- When adding instructors to a teachingCall, displays a message letting the user know that emails have been scheduled to go out.
- Allows the user to re-add instructors to a teaching call, which will change the teaching call form's configuration to match what was set by the user.
- When an instructor submits their teaching call form, they will be redirected to the summary screen and a message will appear at the top informing them they have submitted their preferences.

Issue:
https://trello.com/c/HCLYn9XK/1644-teaching-call-usability-tweaks