### PR TITLE
Correct selective unit sync logic

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/CourseRepository.java
@@ -65,4 +65,6 @@ public interface CourseRepository extends CrudRepository<Course, Long> {
     Course findOneBySubjectCodeAndCourseNumberAndSequencePatternAndScheduleId(String subjectCode, String courseNumber, String sequencePattern, long scheduleId);
 
     List<Course> findByUnitsLow(Float unitsLow);
+
+    List<Course> findByScheduleIn(List<Schedule> scheduleIds);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/ScheduleRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/ScheduleRepository.java
@@ -11,16 +11,12 @@ import org.springframework.data.repository.query.Param;
 import edu.ucdavis.dss.ipa.entities.Schedule;
 
 public interface ScheduleRepository extends CrudRepository<Schedule, Long> {
-	Schedule findOneByYear(long year);
-
 	@Query("FROM Schedule s WHERE s.workgroup.id = :workgroupId AND s.year = :year")
 	Schedule findOneByYearAndWorkgroupWorkgroupId(
 			@Param("workgroupId") long workgroupId,
 			@Param("year") long year);
 
-	Schedule findOneByWorkgroupCodeAndYear(String workgroupCode, long year);
-
-	List<Schedule> findByYear(long year);
+	List<Schedule> findByYearGreaterThanEqual(long year);
 
 	@Query("SELECT DISTINCT t " +
 			" FROM SectionGroup sg, Course c, Term t " +

--- a/src/main/java/edu/ucdavis/dss/ipa/services/CourseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/CourseService.java
@@ -28,6 +28,8 @@ public interface CourseService {
 
 	List<Course> findByUnitsLow(Float unitsLow);
 
+	List<Course> findByScheduleIn(List<Schedule> scheduleIds);
+
 	Course findOrCreateBySubjectCodeAndCourseNumberAndSequencePatternAndTitleAndEffectiveTermCodeAndScheduleId(
 			String subjectCode, String courseNumber, String sequencePattern, String title, String effectiveTermCode, Schedule schedule, boolean copyMetaData);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/ScheduleService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/ScheduleService.java
@@ -13,6 +13,8 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public interface ScheduleService {
 	List<Schedule> findAll();
+
+	List<Schedule> findAllCurrentAndFuture();
 	
 	Schedule saveSchedule(Schedule schedule);
 
@@ -25,10 +27,6 @@ public interface ScheduleService {
 	Schedule findByWorkgroupIdAndYear(long workgroupId, long year);
 
 	Schedule findOrCreateByWorkgroupIdAndYear(long workgroupId, long year);
-
-	List<User> getUserInstructorsByScheduleIdAndTermCode(Long scheduleId, String termCode);
-
-	boolean deleteByScheduleId(long scheduleId);
 
 	boolean isScheduleClosed(long scheduleId);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaCourseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaCourseService.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class JpaCourseService implements CourseService {
-
 	@Inject CourseRepository courseRepository;
 	@Inject ScheduleService scheduleService;
 	@Inject TagService tagService;
@@ -119,7 +118,6 @@ public class JpaCourseService implements CourseService {
 
 			return true;
 		} catch (EmptyResultDataAccessException e) {
-
 			// Could not delete the course offering group because it doesn't exist.
 			// Don't worry about this.
 		}
@@ -153,6 +151,11 @@ public class JpaCourseService implements CourseService {
 
 		course.setTags(tags);
 		return this.courseRepository.save(course);
+	}
+
+	@Override
+	public List<Course> findByScheduleIn(List<Schedule> scheduleIds) {
+		return this.courseRepository.findByScheduleIn(scheduleIds);
 	}
 
 	@Override

--- a/src/main/java/edu/ucdavis/dss/ipa/tasks/UpdateCourseTask.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/tasks/UpdateCourseTask.java
@@ -2,9 +2,11 @@ package edu.ucdavis.dss.ipa.tasks;
 
 import edu.ucdavis.dss.dw.dto.DwCourse;
 import edu.ucdavis.dss.ipa.entities.Course;
+import edu.ucdavis.dss.ipa.entities.Schedule;
 import edu.ucdavis.dss.ipa.repositories.DataWarehouseRepository;
 import edu.ucdavis.dss.ipa.services.ActivityService;
 import edu.ucdavis.dss.ipa.services.CourseService;
+import edu.ucdavis.dss.ipa.services.ScheduleService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -24,9 +26,16 @@ public class UpdateCourseTask {
 
     @Inject DataWarehouseRepository dataWarehouseRepository;
     @Inject CourseService courseService;
+    @Inject ScheduleService scheduleService;
 
     /**
-     * Finds courses with null units low (should not happen) and queries for updates
+     * Finds courses with null units low (does not occur in Banner) and queries for updates.
+     * (Could this also happen if a course is added by the user but it does not yet
+     * exist in Banner, e.g. user is working in a future term?)
+     *
+     * There was also a historical bug where UnitsLow was erroneously set to zero for
+     * some courses. This _is_ allowable in Banner but represents a very small percentage
+     * of courses in any given term, so we double-check zero unit courses as well.
      */
     @Scheduled( fixedDelay = ONE_DAY_IN_MILLISECONDS )
     @Async
@@ -39,7 +48,20 @@ public class UpdateCourseTask {
         log.debug("updateCoursesFromDW() started");
 
         // Update Courses to have the proper units value
+
+        // UnitsLow should not be null, so check these
         List<Course> courses = this.courseService.findByUnitsLow(null);
+
+        // UnitsLow rarely equals 0 and we had a historical bug, so check these for a while
+        // (remove this one after 2018-04-13)
+        courses.addAll(this.courseService.findByUnitsLow(0f));
+
+        // Any current or future schedule should be checked to ensure we're up-to-date
+        // with any Banner changes
+        List<Schedule> currentAndFutureSchedules = this.scheduleService.findAllCurrentAndFuture();
+        List<Course> currentAndFutureCourses = this.courseService.findByScheduleIn(currentAndFutureSchedules);
+
+        courses.addAll(currentAndFutureCourses);
 
         for (Course course : courses) {
             DwCourse dwCourse = dataWarehouseRepository.findCourse(course.getSubjectCode(), course.getCourseNumber(), course.getEffectiveTermCode());


### PR DESCRIPTION
Updates CourseUpdateTask (which really only updates unitsLow and unitsHigh) to ensure we're up-to-date on:

- Zero units courses (we have too many of them due to a historical bug; this check should be removed later)
- Current and future schedules' courses (to ensure we're up-to-date as planning occurs)
