### PR TITLE
Bugfix/new scenario bugs

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSectionGroupCostService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSectionGroupCostService.java
@@ -50,6 +50,7 @@ public class JpaSectionGroupCostService implements SectionGroupCostService {
         sectionGroupCost.setOriginalInstructor(originalSectionGroupCost.getOriginalInstructor());
         sectionGroupCost.setReaderCount(originalSectionGroupCost.getReaderCount());
         sectionGroupCost.setTaCount(originalSectionGroupCost.getTaCount());
+        sectionGroupCost.setReason(originalSectionGroupCost.getReason());
         sectionGroupCost.setSectionCount(originalSectionGroupCost.getSectionCount());
         sectionGroupCost.setCost(originalSectionGroupCost.getCost());
 


### PR DESCRIPTION
The bug was triggered by editing the reason or cost values when the sectionGroupCost did not already exist.

In this scenario:
- Erroneous checks in the template of other values caused the reversion UI to appear incorrectly.
Some symptoms were caused by erroneous checks in the template for existence.
- State was improperly updated.
