### PR TITLE
Bugfix/activity bug

### DIFF
--- a/src/main/java/db/migration/V204__Fix_numeric_activities.java
+++ b/src/main/java/db/migration/V204__Fix_numeric_activities.java
@@ -6,7 +6,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-public class V204__Fix_orphaned_activities implements JdbcMigration {
+public class V204__Fix_numeric_activities implements JdbcMigration {
 
   /**
    * Identify activities that are inappropriately connected to sections that are numeric,
@@ -16,14 +16,6 @@ public class V204__Fix_orphaned_activities implements JdbcMigration {
    */
   @Override
   public void migrate(Connection connection) throws Exception {
-
-    // Look at all activities with a sectionId
-    // If they have a numeric sequence pattern,
-    // Find their sectionGroupId,
-    // Set the sectionGroup and null the section, and save
-
-
-    System.out.println("start");
     PreparedStatement psActivities = connection.prepareStatement("SELECT a.Id, s.sectionGroupId FROM Sections s, Activities a WHERE s.SequenceNumber > 0 AND a.SectionId IS NOT NULL AND a.sectionId = s.Id;");
     connection.setAutoCommit(false);
 
@@ -35,7 +27,7 @@ public class V204__Fix_orphaned_activities implements JdbcMigration {
 
       // Update Activity
       PreparedStatement psUpdateActivity = connection.prepareStatement(
-          " UPDATE `Activities` SET `SectionId` = NULL AND `SectionGroupId` = ? WHERE `Id` = ?;"
+          " UPDATE `Activities` SET `SectionId` = NULL, `SectionGroupId` = ? WHERE `Id` = ?;"
       );
 
       psUpdateActivity.setLong(1, sectionGroupId);
@@ -43,11 +35,9 @@ public class V204__Fix_orphaned_activities implements JdbcMigration {
 
       psUpdateActivity.execute();
       psUpdateActivity.close();
-
-      // Commit changes
-      connection.commit();
     }
-    System.out.println("end");
 
+    // Commit changes
+    connection.commit();
   }
 }

--- a/src/main/java/db/migration/V204__Fix_orphaned_activities.java
+++ b/src/main/java/db/migration/V204__Fix_orphaned_activities.java
@@ -1,0 +1,53 @@
+package db.migration;
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+public class V204__Fix_orphaned_activities implements JdbcMigration {
+
+  /**
+   * Identify activities that are inappropriately connected to sections that are numeric,
+   * And connect them instead to the parent sectionGroup
+   * @param connection
+   * @throws Exception
+   */
+  @Override
+  public void migrate(Connection connection) throws Exception {
+
+    // Look at all activities with a sectionId
+    // If they have a numeric sequence pattern,
+    // Find their sectionGroupId,
+    // Set the sectionGroup and null the section, and save
+
+
+    PreparedStatement psActivities = connection.prepareStatement("SELECT a.Id, s.sectionGroupId FROM Sections s, Activities a WHERE s.SequenceNumber > 0 AND a.SectionId IS NOT NULL AND a.sectionId = s.Id;");
+    connection.setAutoCommit(false);
+
+    ResultSet rsActivities = psActivities.executeQuery();
+
+    while(rsActivities.next()) {
+      Long activityId = rsActivities.getLong("Id");
+      Long sectionGroupId = rsActivities.getLong("SectionGroupId");
+
+      // Get activity
+      PreparedStatement psActivity = connection.prepareStatement(
+          "SELECT * " +
+              "FROM Activities " +
+              "WHERE Id = ?;"
+      );
+
+      psActivity.setLong(1, activityId);
+      ResultSet rsActivity = psActivity.executeQuery();
+
+      while (rsActivity.next()) {
+        // Update activity
+      }
+
+      // Commit changes
+      connection.commit();
+    }
+  }
+}

--- a/src/main/java/db/migration/V204__Fix_orphaned_activities.java
+++ b/src/main/java/db/migration/V204__Fix_orphaned_activities.java
@@ -23,6 +23,7 @@ public class V204__Fix_orphaned_activities implements JdbcMigration {
     // Set the sectionGroup and null the section, and save
 
 
+    System.out.println("start");
     PreparedStatement psActivities = connection.prepareStatement("SELECT a.Id, s.sectionGroupId FROM Sections s, Activities a WHERE s.SequenceNumber > 0 AND a.SectionId IS NOT NULL AND a.sectionId = s.Id;");
     connection.setAutoCommit(false);
 
@@ -32,22 +33,21 @@ public class V204__Fix_orphaned_activities implements JdbcMigration {
       Long activityId = rsActivities.getLong("Id");
       Long sectionGroupId = rsActivities.getLong("SectionGroupId");
 
-      // Get activity
-      PreparedStatement psActivity = connection.prepareStatement(
-          "SELECT * " +
-              "FROM Activities " +
-              "WHERE Id = ?;"
+      // Update Activity
+      PreparedStatement psUpdateActivity = connection.prepareStatement(
+          " UPDATE `Activities` SET `SectionId` = NULL AND `SectionGroupId` = ? WHERE `Id` = ?;"
       );
 
-      psActivity.setLong(1, activityId);
-      ResultSet rsActivity = psActivity.executeQuery();
+      psUpdateActivity.setLong(1, sectionGroupId);
+      psUpdateActivity.setLong(2, activityId);
 
-      while (rsActivity.next()) {
-        // Update activity
-      }
+      psUpdateActivity.execute();
+      psUpdateActivity.close();
 
       // Commit changes
       connection.commit();
     }
+    System.out.println("end");
+
   }
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaActivityService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaActivityService.java
@@ -59,11 +59,9 @@ public class JpaActivityService implements ActivityService {
 		}
 
 		// If activity is numeric, then it should always be tied to a sectionGroup and not a section
-		if (activity.getSection() != null) {
-			if (Utilities.isNumeric(activity.getSection().getSequenceNumber()) == true) {
-				activity.setSectionGroup(activity.getSection().getSectionGroup());
-				activity.setSection(null);
-			}
+		if (activity.getSection() != null && Utilities.isNumeric(activity.getSection().getSequenceNumber()) == true) {
+			activity.setSectionGroup(activity.getSection().getSectionGroup());
+			activity.setSection(null);
 		}
 
 		return this.activityRepository.save(activity);

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaActivityService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaActivityService.java
@@ -2,6 +2,7 @@ package edu.ucdavis.dss.ipa.services.jpa;
 
 import edu.ucdavis.dss.dw.dto.DwActivity;
 import edu.ucdavis.dss.dw.dto.DwSection;
+import edu.ucdavis.dss.ipa.api.helpers.Utilities;
 import edu.ucdavis.dss.ipa.entities.Activity;
 import edu.ucdavis.dss.ipa.entities.ActivityType;
 import edu.ucdavis.dss.ipa.entities.enums.ActivityState;
@@ -55,6 +56,14 @@ public class JpaActivityService implements ActivityService {
 		// Activity frequency should be a minimum of once a week
 		if (activity.getFrequency() < 1) {
 			activity.setFrequency(1);
+		}
+
+		// If activity is numeric, then it should always be tied to a sectionGroup and not a section
+		if (activity.getSection() != null) {
+			if (Utilities.isNumeric(activity.getSection().getSequenceNumber()) == true) {
+				activity.setSectionGroup(activity.getSection().getSectionGroup());
+				activity.setSection(null);
+			}
 		}
 
 		return this.activityRepository.save(activity);


### PR DESCRIPTION
The issue was caused by an assumption in IPA not being followed consistently.
IPA expects:
- letter based sections to have a mix of section based and sectionGroup (shared) activities.
- numeric sections to have only shared activities.
However:
The registrar reconciliation report erroneously added a section based activity when accepting a new activity from banner.

The fix updates activity saving behavior to ensure this assumption is not violated in the future, and adds a migration to fix any activities that are incorrectly referencing a section when they should reference a sectionGroup.

Issue:
https://trello.com/c/pdKYKdHy/1791-schedulingview-activity-on-calendar-with-no-matching-entry-to-edit