### PR TITLE
Bugfix/registrar-report

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/registrarReconciliationReport/views/factories/JpaReportViewFactory.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/registrarReconciliationReport/views/factories/JpaReportViewFactory.java
@@ -210,8 +210,8 @@ public class JpaReportViewFactory implements ReportViewFactory {
 								a.getActivityTypeCode().getActivityTypeCode(),
 								a.getLocationDescription(),
 								a.getDayIndicator(),
-								a.getStartTime() != null ? new SimpleDateFormat("HHmm").format(a.getStartTime()) : "",
-								a.getEndTime() != null ? new SimpleDateFormat("HHmm").format(a.getEndTime()) : "",
+								a.getStartTime() != null ? new SimpleDateFormat("HHmm").format(a.getStartTime()) : null,
+								a.getEndTime() != null ? new SimpleDateFormat("HHmm").format(a.getEndTime()) : null,
 								section.getSectionGroup().getCourse().getSubjectCode(),
 								section.getSectionGroup().getCourse().getCourseNumber(),
 								section.getSequenceNumber()
@@ -227,8 +227,8 @@ public class JpaReportViewFactory implements ReportViewFactory {
 								a.getActivityTypeCode().getActivityTypeCode(),
 								a.getLocationDescription(),
 								a.getDayIndicator(),
-								a.getStartTime() != null ? new SimpleDateFormat("HHmm").format(a.getStartTime()) : "",
-								a.getEndTime() != null ? new SimpleDateFormat("HHmm").format(a.getEndTime()) : "",
+								a.getStartTime() != null ? new SimpleDateFormat("HHmm").format(a.getStartTime()) : null,
+								a.getEndTime() != null ? new SimpleDateFormat("HHmm").format(a.getEndTime()) : null,
 								section.getSectionGroup().getCourse().getSubjectCode(),
 								section.getSectionGroup().getCourse().getCourseNumber(),
 								section.getSequenceNumber()


### PR DESCRIPTION
The logic preparing 'diffs' for the front end should not convert null to empty string in start/end times, this confuses the javers.compare() method and causes diffs to be created that offer to change 'none' to 'none'

Issue:
https://trello.com/c/JnAVtRuF/1843-bug-in-reconciliation-report