### PR TITLE
ScheduleSummary: Ensure assigned instructors are available in payload

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/scheduleSummaryReport/views/ScheduleSummaryReportView.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/scheduleSummaryReport/views/ScheduleSummaryReportView.java
@@ -2,7 +2,9 @@ package edu.ucdavis.dss.ipa.api.components.scheduleSummaryReport.views;
 
 import edu.ucdavis.dss.ipa.entities.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ScheduleSummaryReportView {
     List<Course> courses = new ArrayList<Course>();
@@ -12,7 +14,7 @@ public class ScheduleSummaryReportView {
     List<SupportAssignment> supportAssignments = new ArrayList<>();
     List<SupportStaff> supportStaffList = new ArrayList<>();
     List<TeachingAssignment> teachingAssignments = new ArrayList<TeachingAssignment>();
-    List<Instructor> instructors = new ArrayList<Instructor>();
+    Set<Instructor> instructors = new HashSet<>();
     List<InstructorType> instructorTypes = new ArrayList<>();
     String termCode;
     Long year;
@@ -22,7 +24,7 @@ public class ScheduleSummaryReportView {
                                      List<Section> sections,
                                      List<Activity> activities,
                                      List<TeachingAssignment> teachingAssignments,
-                                     List<Instructor> instructors,
+                                     Set<Instructor> instructors,
                                      String termCode,
                                      Long year,
                                      List<SupportAssignment> supportAssignments,
@@ -65,11 +67,11 @@ public class ScheduleSummaryReportView {
         this.teachingAssignments = teachingAssignments;
     }
 
-    public List<Instructor> getInstructors() {
+    public Set<Instructor> getInstructors() {
         return instructors;
     }
 
-    public void setInstructors(List<Instructor> instructors) {
+    public void setInstructors(Set<Instructor> instructors) {
         this.instructors = instructors;
     }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/scheduleSummaryReport/views/factories/JpaScheduleSummaryViewFactory.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/scheduleSummaryReport/views/factories/JpaScheduleSummaryViewFactory.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.View;
 
 import javax.inject.Inject;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class JpaScheduleSummaryViewFactory implements ScheduleSummaryViewFactory {
@@ -21,6 +23,7 @@ public class JpaScheduleSummaryViewFactory implements ScheduleSummaryViewFactory
     @Inject SupportStaffService supportStaffService;
     @Inject TermService termService;
     @Inject InstructorTypeService instructorTypeService;
+    @Inject InstructorService instructorService;
 
     @Override
     public ScheduleSummaryReportView createScheduleSummaryReportView(long workgroupId, long year, String shortTermCode) {
@@ -30,7 +33,13 @@ public class JpaScheduleSummaryViewFactory implements ScheduleSummaryViewFactory
         List<Section> sections = sectionService.findVisibleByWorkgroupIdAndYearAndTermCode(workgroupId, year, shortTermCode);
         List<Activity> activities = activityService.findVisibleByWorkgroupIdAndYearAndTermCode(workgroupId, year, shortTermCode);
         List<TeachingAssignment> teachingAssignments = schedule.getTeachingAssignments();
-        List<Instructor> instructors = userRoleService.getInstructorsByWorkgroupId(workgroupId);
+
+        Set<Instructor> instructors = new HashSet<Instructor>();
+        Set<Instructor> activeInstructors = new HashSet<>(userRoleService.getInstructorsByWorkgroupId(workgroupId));
+        Set<Instructor> assignedInstructors = new HashSet<> (instructorService.findAssignedByScheduleId(schedule.getId()));
+        instructors.addAll(activeInstructors);
+        instructors.addAll(assignedInstructors);
+
         List<SupportAssignment> supportAssignments = supportAssignmentService.findByScheduleIdAndTermCode(schedule.getId(), shortTermCode);
         List<SupportStaff> supportStaffList = supportStaffService.findBySupportAssignments(supportAssignments);
         List<InstructorType> instructorTypes = instructorTypeService.getAllInstructorTypes();


### PR DESCRIPTION
Issue:
https://trello.com/c/oeBJHxzu/1889-schedulesummaryreport-instructor-names-not-displaying-properly-when-removed-from-workgroup

Fixes a bug where the schedule summary report didn't have the complete list of assigned instructors available to it.
<img width="1167" alt="screen shot 2018-08-08 at 10 02 22 am" src="https://user-images.githubusercontent.com/1776859/43852318-c606fa08-9af1-11e8-90e6-d986cb3d30b3.png">
<img width="1144" alt="screen shot 2018-08-08 at 10 02 19 am" src="https://user-images.githubusercontent.com/1776859/43852319-c61b7b9a-9af1-11e8-8189-18e1d6dee090.png">
<img width="1180" alt="screen shot 2018-08-08 at 10 03 27 am" src="https://user-images.githubusercontent.com/1776859/43852363-e2387a6c-9af1-11e8-85cb-e3afa147d205.png">
