### PR TITLE
Updating character limits on lineItem notes and description

### DIFF
--- a/src/main/resources/db/migration/V211__Update_limit_on_lineItem_description_and_notes.sql
+++ b/src/main/resources/db/migration/V211__Update_limit_on_lineItem_description_and_notes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `LineItems` CHANGE COLUMN `Notes` `Notes` VARCHAR(750) NULL;
+ALTER TABLE `LineItems` CHANGE COLUMN `Description` `Description` VARCHAR(500) NULL;


### PR DESCRIPTION
Issue:
https://trello.com/c/lJZvZRkT/1895-1-budgetview-ui-does-not-enforce-varchar100-limit-on-the-lineitem-description-field