### PR TITLE
When importing a banner course, the IPA course should copy the units as well

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaCourseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaCourseService.java
@@ -248,6 +248,9 @@ public class JpaCourseService implements CourseService {
 		course.setEffectiveTermCode(courseDTO.getEffectiveTermCode());
 		course.setSchedule(courseDTO.getSchedule());
 		course.setTags(tags);
+		course.setUnitsHigh(courseDTO.getUnitsHigh());
+		course.setUnitsLow(courseDTO.getUnitsLow());
+
 		courseRepository.save(course);
 
 		return course;


### PR DESCRIPTION
Issue:
https://trello.com/c/x73JjRon/1904-05-recently-imported-courses-via-courses-screen-display-null-units-in-instructor-assignments-screen