### PR TITLE
Fix bug in reconciliation report where duplicate activityTypes were ignored

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/registrarReconciliationReport/views/ActivityDiffDto.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/registrarReconciliationReport/views/ActivityDiffDto.java
@@ -23,11 +23,9 @@ public class ActivityDiffDto {
 			String dayIndicator,
 			String startTime,
 			String endTime,
-			String subjectCode,
-			String courseNumber,
-			String sequenceNumber) {
+			String uniqueKey) {
 		setId(activityId);
-		setUniqueKey(subjectCode + "-" + courseNumber + "-" + sequenceNumber + "-" + typeCode);
+		setUniqueKey(uniqueKey);
 		setTypeCode(typeCode);
 
 		setBannerLocation(bannerLocation);


### PR DESCRIPTION
The issue was caused by an implicit assumption in ipa that activity subj/course/sequence/activityTypeCode would result in a uniqueKey within activities tied to that section. This is not necessarily true, as a section can have multiple activities of the same activityTypeCode. To ensure javers properly differentiates the activities in this scenario I added a counter to the uniqueKey.

Issue:
https://trello.com/c/tiRBKKlc/1900-05-reconciliationreport-appears-to-not-be-pulling-correct-data-from-banner