### PR TITLE
Feature/copy funds

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
@@ -96,6 +96,7 @@ public class BudgetViewController {
     @ResponseBody
     public BudgetScenarioView createBudgetScenario(@PathVariable long budgetId,
                                                    @RequestParam(value="scenarioId", required = false) Long scenarioId,
+                                                   @RequestParam(value = "copyFunds", required = false) boolean copyFunds,
                                                    @RequestBody BudgetScenario budgetScenarioDTO,
                                                    HttpServletResponse httpResponse) {
         // Ensure valid params
@@ -115,6 +116,12 @@ public class BudgetViewController {
         // If a budget scenario id was supplied, copy data, else create from schedule
         if (scenarioId != null && scenarioId != 0) {
             budgetScenario = budgetScenarioService.createFromExisting(scenarioId, budgetScenarioDTO.getName());
+
+            if (copyFunds) {
+                BudgetScenario originalBudgetScenario = budgetScenarioService.findById(budgetScenarioDTO.getId());
+                List<LineItem> lineItems = lineItemService.duplicateFunds(budgetScenario, originalBudgetScenario);
+                budgetScenario.setLineItems(lineItems);
+            }
         } else {
             budgetScenario = budgetScenarioService.findOrCreate(budget, budgetScenarioDTO.getName());
         }

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/budget/BudgetViewController.java
@@ -115,13 +115,7 @@ public class BudgetViewController {
 
         // If a budget scenario id was supplied, copy data, else create from schedule
         if (scenarioId != null && scenarioId != 0) {
-            budgetScenario = budgetScenarioService.createFromExisting(scenarioId, budgetScenarioDTO.getName());
-
-            if (copyFunds) {
-                BudgetScenario originalBudgetScenario = budgetScenarioService.findById(budgetScenarioDTO.getId());
-                List<LineItem> lineItems = lineItemService.duplicateFunds(budgetScenario, originalBudgetScenario);
-                budgetScenario.setLineItems(lineItems);
-            }
+            budgetScenario = budgetScenarioService.createFromExisting(scenarioId, budgetScenarioDTO.getName(), copyFunds);
         } else {
             budgetScenario = budgetScenarioService.findOrCreate(budget, budgetScenarioDTO.getName());
         }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/BudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/BudgetScenarioService.java
@@ -14,7 +14,7 @@ public interface BudgetScenarioService {
 
     void deleteById(long budgetScenarioId);
 
-    BudgetScenario createFromExisting(Long scenarioId, String name);
+    BudgetScenario createFromExisting(Long scenarioId, String name, boolean copyFunds);
 
     BudgetScenario update(BudgetScenario budgetScenario);
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/LineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/LineItemService.java
@@ -1,9 +1,7 @@
 package edu.ucdavis.dss.ipa.services;
 
-import edu.ucdavis.dss.ipa.entities.Budget;
 import edu.ucdavis.dss.ipa.entities.BudgetScenario;
 import edu.ucdavis.dss.ipa.entities.LineItem;
-import edu.ucdavis.dss.ipa.entities.TeachingAssignment;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
@@ -25,4 +23,6 @@ public interface LineItemService {
     void deleteMany(List<Long> lineItemIds);
 
     List<LineItem> findbyWorkgroupIdAndYear(long workgroupId, long year);
+
+    List<LineItem> duplicateFunds(BudgetScenario budgetScenario, BudgetScenario originalBudgetScenario);
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -148,7 +148,8 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
 
         // Clone lineItems if option is selected
         if (copyFunds) {
-            List<LineItem> lineItems = lineItemService.duplicateFunds(budgetScenario, originalBudgetScenario);
+            List<LineItem> lineItems = budgetScenario.getLineItems();
+            lineItems.addAll(lineItemService.duplicateFunds(budgetScenario, originalBudgetScenario));
             budgetScenario.setLineItems(lineItems);
         }
 

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -121,7 +121,7 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
      */
     @Transactional
     @Override
-    public BudgetScenario createFromExisting(Long scenarioId, String name) {
+    public BudgetScenario createFromExisting(Long scenarioId, String name, boolean copyFunds) {
         BudgetScenario originalBudgetScenario = budgetScenarioRepository.findById(scenarioId);
 
         if (originalBudgetScenario == null) {
@@ -146,15 +146,12 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
         budgetScenario.setSectionGroupCosts(sectionGroupCostList);
         budgetScenario = budgetScenarioRepository.save(budgetScenario);
 
-        // Clone lineItems from one scenario to another
-        List<LineItem> lineItems = budgetScenario.getLineItems();
-
-        for(LineItem originalLineItem : originalBudgetScenario.getLineItems()) {
-            LineItem lineItem = lineItemService.createDuplicate(originalLineItem, budgetScenario);
-            lineItems.add(lineItem);
+        // Clone lineItems if option is selected
+        if (copyFunds) {
+            List<LineItem> lineItems = lineItemService.duplicateFunds(budgetScenario, originalBudgetScenario);
+            budgetScenario.setLineItems(lineItems);
         }
 
-        budgetScenario.setLineItems(lineItems);
         budgetScenario = budgetScenarioRepository.save(budgetScenario);
 
         return budgetScenario;

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaBudgetScenarioService.java
@@ -128,8 +128,7 @@ public class JpaBudgetScenarioService implements BudgetScenarioService {
             return null;
         }
 
-        BudgetScenario budgetScenario = null;
-        budgetScenario = new BudgetScenario();
+        BudgetScenario budgetScenario = new BudgetScenario();
         budgetScenario.setBudget(originalBudgetScenario.getBudget());
         budgetScenario.setName(name);
         budgetScenario.setActiveTermsBlob(originalBudgetScenario.getActiveTermsBlob());

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
@@ -83,6 +83,8 @@ public class JpaLineItemService implements LineItemService {
         lineItem.setAmount(originalLineItem.getAmount());
         lineItem.setDescription(originalLineItem.getDescription());
         lineItem.setLineItemCategory(originalLineItem.getLineItemCategory());
+        lineItem.setHidden(originalLineItem.getHidden());
+        lineItem.setTeachingAssignment(originalLineItem.getTeachingAssignment());
 
         return this.lineItemRepository.save(lineItem);
     }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaLineItemService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -97,5 +98,17 @@ public class JpaLineItemService implements LineItemService {
     @Override
     public List<LineItem> findbyWorkgroupIdAndYear(long workgroupId, long year) {
         return lineItemRepository.findbyWorkgroupIdAndYear(workgroupId, year);
+    }
+
+    @Override
+    public List<LineItem> duplicateFunds(BudgetScenario budgetScenario, BudgetScenario originalBudgetScenario) {
+        List<LineItem> lineItems = new ArrayList<>();
+
+        for (LineItem originalLineItem : originalBudgetScenario.getLineItems()) {
+            LineItem lineItem = this.createDuplicate(originalLineItem, budgetScenario);
+            lineItems.add(lineItem);
+        }
+
+        return lineItems;
     }
 }

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSectionGroupCostService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaSectionGroupCostService.java
@@ -61,6 +61,7 @@ public class JpaSectionGroupCostService implements SectionGroupCostService {
         sectionGroupCost.setReason(originalSectionGroupCost.getReason());
         sectionGroupCost.setSectionCount(originalSectionGroupCost.getSectionCount());
         sectionGroupCost.setCost(originalSectionGroupCost.getCost());
+        sectionGroupCost.setDisabled(originalSectionGroupCost.isDisabled());
 
         return this.sectionGroupCostRepository.save(sectionGroupCost);
     }


### PR DESCRIPTION
Adds a checkbox to the scenario creation modal when another scenario is targeted as the source, and defaults to ‘on’ to indicate the 'funds' tab should be copied.

Issue:
https://trello.com/c/hOeOMqrX/1981-budget-module-ability-to-copy-funds-when-cloning-a-scenario
