### PR TITLE
Add sendEmail flag to clarify e-mailing behavior

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/instructionalSupport/InstructionalSupportCallsController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/instructionalSupport/InstructionalSupportCallsController.java
@@ -80,6 +80,7 @@ public class InstructionalSupportCallsController {
             InstructorSupportCallResponse instructorSupportCallResponse = instructorSupportCallResponseService.findOneById(responseId);
             instructorSupportCallResponse.setNextContactAt(instructorSupportCallContactDTO.getNextContactAt());
             instructorSupportCallResponse.setMessage(instructorSupportCallContactDTO.getMessage());
+            instructorSupportCallResponse.setSendEmail(true);
             instructorSupportCallResponse = instructorSupportCallResponseService.update(instructorSupportCallResponse);
             instructorResponses.add(instructorSupportCallResponse);
         }
@@ -168,6 +169,7 @@ public class InstructionalSupportCallsController {
         for (Long responseId : studentSupportCallContactDTO.responseIds) {
             StudentSupportCallResponse studentSupportCallResponse = studentSupportCallResponseService.findOneById(responseId);
 
+            studentSupportCallResponse.setSendEmail(true);
             studentSupportCallResponse.setNextContactAt(studentSupportCallContactDTO.getNextContactAt());
             studentSupportCallResponse.setMessage(studentSupportCallContactDTO.getMessage());
             studentSupportCallResponse = studentSupportCallResponseService.update(studentSupportCallResponse);
@@ -258,6 +260,7 @@ public class InstructionalSupportCallsController {
         instructorResponseDTO.setAllowSubmissionAfterDueDate(addInstructorsDTO.getAllowSubmissionAfterDueDate());
 
         if (addInstructorsDTO.getSendEmail() != null && addInstructorsDTO.getSendEmail() == true) {
+            instructorResponseDTO.setSendEmail(true);
             instructorResponseDTO.setMessage(addInstructorsDTO.getMessage());
 
             Date now = Calendar.getInstance().getTime();
@@ -404,6 +407,7 @@ public class InstructionalSupportCallsController {
 
         if (addStudentsDTO.getSendEmail() != null && addStudentsDTO.getSendEmail() == true) {
             studentResponseDTO.setMessage(addStudentsDTO.getMessage());
+            studentResponseDTO.setSendEmail(true);
 
             Date now = Calendar.getInstance().getTime();
             studentResponseDTO.setNextContactAt(now);

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/teachingCall/TeachingCallStatusViewController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/teachingCall/TeachingCallStatusViewController.java
@@ -63,6 +63,7 @@ public class TeachingCallStatusViewController {
             TeachingCallReceipt slotTeachingCallReceipt = teachingCallReceiptService.findOneById(receiptId);
             slotTeachingCallReceipt.setNextContactAt(contactInstructorsDTO.getNextContactAt());
             slotTeachingCallReceipt.setMessage(contactInstructorsDTO.getMessage());
+            slotTeachingCallReceipt.setSendEmail(true);
             slotTeachingCallReceipt = teachingCallReceiptService.save(slotTeachingCallReceipt);
             teachingCallReceipts.add(slotTeachingCallReceipt);
         }
@@ -153,6 +154,7 @@ public class TeachingCallStatusViewController {
 
         if (addInstructorsDTO.getSendEmail() == true) {
             receiptDTO.setMessage(addInstructorsDTO.getMessage());
+            receiptDTO.setSendEmail(true);
 
             Date now = Calendar.getInstance().getTime();
             receiptDTO.setNextContactAt(now);

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/InstructorSupportCallResponse.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/InstructorSupportCallResponse.java
@@ -18,7 +18,9 @@ public class InstructorSupportCallResponse implements Serializable {
     private String message, termCode;
     private Date startDate, dueDate, lastContactedAt, nextContactAt;
     private Instructor instructor;
-    private boolean submitted, allowSubmissionAfterDueDate;
+    private boolean submitted;
+    private boolean allowSubmissionAfterDueDate;
+    private boolean sendEmail;
     private String generalComments;
 
     @Id
@@ -52,6 +54,15 @@ public class InstructorSupportCallResponse implements Serializable {
 
     public void setSubmitted(boolean submitted) {
         this.submitted = submitted;
+    }
+
+    @Column (nullable = false)
+    public boolean isSendEmail() {
+        return sendEmail;
+    }
+
+    public void setSendEmail(boolean sendEmail) {
+        this.sendEmail = sendEmail;
     }
 
     @Column (nullable = false)

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/StudentSupportCallResponse.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/StudentSupportCallResponse.java
@@ -32,6 +32,7 @@ public class StudentSupportCallResponse implements Serializable {
     private boolean collectGeneralComments, collectTeachingQualifications, collectPreferenceComments;
     private boolean collectEligibilityConfirmation, collectTeachingAssistantPreferences, collectReaderPreferences;
     private boolean collectAssociateInstructorPreferences, requirePreferenceComments, collectAvailabilityByCrn, collectAvailabilityByGrid, collectLanguageProficiencies;
+    private boolean sendEmail;
     private Integer languageProficiency;
 
     @Id
@@ -275,6 +276,15 @@ public class StudentSupportCallResponse implements Serializable {
 
     public void setLanguageProficiency(Integer languageProficiency) {
         this.languageProficiency = languageProficiency;
+    }
+
+    @Column (nullable = false)
+    public boolean isSendEmail() {
+        return sendEmail;
+    }
+
+    public void setSendEmail(boolean sendEmail) {
+        this.sendEmail = sendEmail;
     }
 
     @JsonProperty("supportStaffId")

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/TeachingCallReceipt.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/TeachingCallReceipt.java
@@ -32,6 +32,7 @@ public class TeachingCallReceipt implements Serializable {
 
 	private Instructor instructor;
 	private Boolean isDone = false, showUnavailabilities = true;
+	private boolean sendEmail;
 	private Date lastContactedAt, nextContactAt, dueDate;
 	private Schedule schedule;
 	private String comment, termsBlob, message;
@@ -141,6 +142,15 @@ public class TeachingCallReceipt implements Serializable {
 
 	public void setMessage(String message) {
 		this.message = message;
+	}
+
+	@Column (nullable = false)
+	public boolean isSendEmail() {
+		return sendEmail;
+	}
+
+	public void setSendEmail(boolean sendEmail) {
+		this.sendEmail = sendEmail;
 	}
 
 	@JsonProperty("instructorId")

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaInstructorSupportCallResponseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaInstructorSupportCallResponseService.java
@@ -81,21 +81,22 @@ public class JpaInstructorSupportCallResponseService implements InstructorSuppor
         }
 
         Calendar now = Calendar.getInstance();
-        int currentYear = now.get(Calendar.YEAR);
-
         java.util.Date utilDate = now.getTime();
         java.sql.Date currentDate = new Date(utilDate.getTime());
 
         for (Schedule schedule : workgroup.getSchedules()) {
             // Check teachingCallReceipts to see if messages need to be sent
             for (InstructorSupportCallResponse instructorSupportCallResponse : schedule.getInstructorSupportCallResponses()) {
+                // Do not process for e-mailing if we are not to e-mail
+                if (instructorSupportCallResponse.isSendEmail() == false) {
+                    continue;
+                }
 
                 // Is an email scheduled to be sent?
                 if (instructorSupportCallResponse.getNextContactAt() != null) {
                     long currentTime = currentDate.getTime();
                     long contactAtTime = instructorSupportCallResponse.getNextContactAt().getTime();
 
-                    // Is it time to send that email?
                     if (currentTime > contactAtTime) {
                         sendSupportCall(instructorSupportCallResponse, currentDate);
                     }
@@ -125,14 +126,11 @@ public class JpaInstructorSupportCallResponseService implements InstructorSuppor
                         } else if (timeSinceLastContact != null && timeSinceLastContact > oneDayInMilliseconds && currentTime < dueDateTime) {
                             sendSupportCallWarning(instructorSupportCallResponse, currentDate);
                         }
-
                     }
                 }
             }
         }
-
     }
-
 
     /**
      * Builds the email and triggers sending of the support Call.
@@ -266,6 +264,7 @@ public class JpaInstructorSupportCallResponseService implements InstructorSuppor
             instructorResponse.setSchedule(instructorResponseDTO.getSchedule());
             instructorResponse.setInstructor(instructor);
             instructorResponse.setSubmitted(false);
+            instructorResponse.setSendEmail(instructorResponseDTO.isSendEmail());
             instructorResponse.setMessage(instructorResponseDTO.getMessage());
             instructorResponse.setNextContactAt(instructorResponseDTO.getNextContactAt());
             instructorResponse.setTermCode(instructorResponseDTO.getTermCode());

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaStudentSupportCallResponseService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaStudentSupportCallResponseService.java
@@ -102,6 +102,10 @@ public class JpaStudentSupportCallResponseService implements StudentSupportCallR
         for (Schedule schedule : workgroup.getSchedules()) {
             // Check teachingCallReceipts to see if messages need to be sent
             for (StudentSupportCallResponse studentSupportCallResponse : schedule.getStudentSupportCallResponses()) {
+                // Do not process for e-mailing if we are not to e-mail
+                if(studentSupportCallResponse.isSendEmail() == false) {
+                    continue;
+                }
 
                 // Is an email scheduled to be sent?
                 if (studentSupportCallResponse.getNextContactAt() != null) {
@@ -303,6 +307,7 @@ public class JpaStudentSupportCallResponseService implements StudentSupportCallR
             studentResponse.setMinimumNumberOfPreferences(studentResponseDTO.getMinimumNumberOfPreferences());
             studentResponse.setAllowSubmissionAfterDueDate(studentResponseDTO.isAllowSubmissionAfterDueDate());
 
+            studentResponse.setSendEmail(studentResponseDTO.isSendEmail());
             studentResponse.setMessage(studentResponseDTO.getMessage());
             studentResponse.setNextContactAt(studentResponseDTO.getNextContactAt());
             studentResponse.setTermCode(studentResponseDTO.getTermCode());

--- a/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/services/jpa/JpaTeachingCallReceiptService.java
@@ -72,6 +72,11 @@ public class JpaTeachingCallReceiptService implements TeachingCallReceiptService
 		for (Schedule schedule : workgroup.getSchedules()) {
 			// Check teachingCallReceipts to see if messages need to be sent
 			for (TeachingCallReceipt teachingCallReceipt : schedule.getTeachingCallReceipts()) {
+				// Do not process for e-mailing if we are not to e-mail
+				if (teachingCallReceipt.isSendEmail() == false) {
+					continue;
+				}
+
 				// Send scheduled email if the send date has been passed
 				if (teachingCallReceipt.getNextContactAt() != null) {
 					long currentTime = currentDate.getTime();
@@ -127,7 +132,7 @@ public class JpaTeachingCallReceiptService implements TeachingCallReceiptService
 		String loginId = teachingCallReceipt.getInstructor().getLoginId();
 
 		// loginId is necessary to map to a user and email
-		if ( loginId == null) {
+		if (loginId == null) {
 			log.error("Attempted to send notification to instructor id '" + teachingCallReceipt.getInstructor().getId() + "' but loginId was null.");
 			return;
 		}
@@ -248,6 +253,7 @@ public class JpaTeachingCallReceiptService implements TeachingCallReceiptService
 			teachingCallReceipt.setIsDone(false);
 			teachingCallReceipt.setMessage(teachingCallReceiptDTO.getMessage());
 			teachingCallReceipt.setNextContactAt(teachingCallReceiptDTO.getNextContactAt());
+			teachingCallReceipt.setSendEmail(teachingCallReceiptDTO.isSendEmail());
 			teachingCallReceipt.setShowUnavailabilities(teachingCallReceiptDTO.getShowUnavailabilities());
 			teachingCallReceipt.setTermsBlob(teachingCallReceiptDTO.getTermsBlob());
 			teachingCallReceipt.setDueDate(teachingCallReceiptDTO.getDueDate());

--- a/src/main/resources/db/migration/V218__AddEmailFlagToCalls.sql
+++ b/src/main/resources/db/migration/V218__AddEmailFlagToCalls.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `InstructorSupportCallResponses` ADD COLUMN `SendEmail` TINYINT(1) NOT NULL;
+ALTER TABLE `StudentSupportCallResponses` ADD COLUMN `SendEmail` TINYINT(1) NOT NULL;
+ALTER TABLE `TeachingCallReceipts` ADD COLUMN `SendEmail` TINYINT(1) NOT NULL;


### PR DESCRIPTION
The current e-mailing behavior does not have a 'send e-mail' flag but instead calculates whether an e-mail is required based on the 'nextContact', 'lastContact', and 'message' fields.

This has caused bugs before. Yesterday, it caused another one: the reminder warning e-mails do not respect the 'no e-mail' flag.

So, I've implemented a hard 'sendEmail' flag to avoid confusion and clarify behavior.

Please test this to ensure it works correctly. The send e-mail / do not send e-mail is highly visible functionality that directly impacts our customer experience.