### PR TITLE
Bugfix/instructor assignment list dropdown preferences order

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -213,11 +213,8 @@ public class AssignmentViewTeachingAssignmentController {
                 sectionGroup = sectionGroupService.save(sectionGroup);
             }
 
-            // Associate teachingAssignment to the newly created sectionGroup and remove the suggested course metadata
+            // Associate teachingAssignment to the newly created sectionGroup
             originalTeachingAssignment.setSectionGroup(sectionGroup);
-            originalTeachingAssignment.setSuggestedEffectiveTermCode(null);
-            originalTeachingAssignment.setSuggestedSubjectCode(null);
-            originalTeachingAssignment.setSuggestedCourseNumber(null);
             originalTeachingAssignment.setApproved(teachingAssignment.isApproved());
 
             teachingAssignmentService.saveAndAddInstructorType(originalTeachingAssignment);

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -215,6 +215,10 @@ public class AssignmentViewTeachingAssignmentController {
 
             // Associate teachingAssignment to the newly created sectionGroup
             originalTeachingAssignment.setSectionGroup(sectionGroup);
+            originalTeachingAssignment.setSuggestedEffectiveTermCode(null);
+            originalTeachingAssignment.setSuggestedSubjectCode(null);
+            originalTeachingAssignment.setSuggestedCourseNumber(null);
+            originalTeachingAssignment.setSuggestedTitle(null);
             originalTeachingAssignment.setApproved(teachingAssignment.isApproved());
 
             teachingAssignmentService.saveAndAddInstructorType(originalTeachingAssignment);
@@ -222,6 +226,7 @@ public class AssignmentViewTeachingAssignmentController {
             originalTeachingAssignment.setSuggestedCourseNumber(teachingAssignment.getSuggestedCourseNumber());
             originalTeachingAssignment.setSuggestedSubjectCode(teachingAssignment.getSuggestedSubjectCode());
             originalTeachingAssignment.setSuggestedEffectiveTermCode(teachingAssignment.getSuggestedEffectiveTermCode());
+            originalTeachingAssignment.setSuggestedTitle(teachingAssignment.getSuggestedTitle());
 
             return originalTeachingAssignment;
         }

--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -213,7 +213,7 @@ public class AssignmentViewTeachingAssignmentController {
                 sectionGroup = sectionGroupService.save(sectionGroup);
             }
 
-            // Associate teachingAssignment to the newly created sectionGroup
+            // Associate teachingAssignment to the newly created sectionGroup and remove the suggested course metadata
             originalTeachingAssignment.setSectionGroup(sectionGroup);
             originalTeachingAssignment.setSuggestedEffectiveTermCode(null);
             originalTeachingAssignment.setSuggestedSubjectCode(null);


### PR DESCRIPTION
Issue: https://trello.com/c/sTJ3CNxy/1998-instructor-assignments-by-instructor-dropdown-of-preferences-should-list-the-order-1-2-3
Frontend PR: https://github.com/ucdavis/ipa-client-angular/pull/1608

Keep suggested course metadata on teachingAssignment