### PR TITLE
Do not assume preferences exist

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/api/components/assignment/AssignmentViewTeachingAssignmentController.java
@@ -414,8 +414,10 @@ public class AssignmentViewTeachingAssignmentController {
             teachingAssignment.setInstructor(instructor);
             teachingAssignment.setFromInstructor(true);
 
-            TeachingAssignment maxPriorityTeachingAssignment = teachingAssignmentService.findByScheduleIdAndInstructorId(schedule.getId(), instructor.getId()).stream().max(Comparator.comparing(TeachingAssignment::getPriority)).get();
-            Integer priority = maxPriorityTeachingAssignment.getPriority() + 1;
+            List<TeachingAssignment> currentAssignments = teachingAssignmentService.findByScheduleIdAndInstructorId(schedule.getId(), instructor.getId());
+            Integer currentMaxPriority = currentAssignments.size() > 0 ? currentAssignments.stream().max(Comparator.comparing(TeachingAssignment::getPriority)).get().getPriority() : 0;
+
+            Integer priority = currentMaxPriority + 1;
             teachingAssignment.setPriority(priority);
 
             teachingAssignments.add(teachingAssignmentService.saveAndAddInstructorType(teachingAssignment));


### PR DESCRIPTION
Issue:
https://trello.com/c/YT4nfc4i/2036-teachingcallform-add-preference-error-caused-by-a-backend-error-in-priority-setting-logic

Was caused by a backend error in priority calculation. Previously it assumed there would always be some preferences, when this is unlikely to be true.