### PR TITLE
[rtt-131] teaching call cannot remove preferences hotfix

### DIFF
--- a/src/main/java/edu/ucdavis/dss/ipa/entities/SectionGroup.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/SectionGroup.java
@@ -63,7 +63,7 @@ public class SectionGroup extends BaseEntity {
 	}
 
 	@JsonIgnore
-	@OneToMany(mappedBy="sectionGroup", cascade=CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy="sectionGroup", orphanRemoval = true)
 	public List<TeachingAssignment> getTeachingAssignments() {
 		return teachingAssignments;
 	}

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/SectionGroupCostInstructor.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/SectionGroupCostInstructor.java
@@ -50,7 +50,7 @@ public class SectionGroupCostInstructor extends BaseEntity {
         this.sectionGroupCost = sectionGroupCost;
     }
 
-    @OneToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TeachingAssignmentId")
     @JsonIgnore
     public TeachingAssignment getTeachingAssignment() {

--- a/src/main/java/edu/ucdavis/dss/ipa/entities/TeachingAssignment.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/entities/TeachingAssignment.java
@@ -8,7 +8,6 @@ import edu.ucdavis.dss.ipa.api.deserializers.TeachingAssignmentDeserializer;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * Represents a teaching assignment or teaching preference (an unapproved assignment that may be created by
@@ -283,8 +282,8 @@ public class TeachingAssignment implements Serializable {
 
         return null;
     }
-    @JsonProperty("sectionGroupCostInstructor")
-    @OneToOne(mappedBy="teachingAssignment", fetch = FetchType.LAZY, cascade=CascadeType.ALL, orphanRemoval = true)
+
+    @OneToOne(mappedBy="teachingAssignment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     public SectionGroupCostInstructor getSectionGroupCostInstructor() {
         return sectionGroupCostInstructor;

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/SectionGroupCostInstructorRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/SectionGroupCostInstructorRepository.java
@@ -1,7 +1,5 @@
 package edu.ucdavis.dss.ipa.repositories;
 
-import edu.ucdavis.dss.ipa.entities.SectionGroup;
-import edu.ucdavis.dss.ipa.entities.SectionGroupCost;
 import edu.ucdavis.dss.ipa.entities.SectionGroupCostInstructor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/edu/ucdavis/dss/ipa/repositories/TeachingAssignmentRepository.java
+++ b/src/main/java/edu/ucdavis/dss/ipa/repositories/TeachingAssignmentRepository.java
@@ -1,7 +1,6 @@
 package edu.ucdavis.dss.ipa.repositories;
 
 import edu.ucdavis.dss.ipa.entities.Schedule;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
@@ -9,7 +8,6 @@ import edu.ucdavis.dss.ipa.entities.Instructor;
 import edu.ucdavis.dss.ipa.entities.SectionGroup;
 import edu.ucdavis.dss.ipa.entities.TeachingAssignment;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 


### PR DESCRIPTION
It looks like removing the `teachingAssignmentRepository.deleteById()` method broke the ability to delete teaching preferences (teachingAssignment w/ fromInstructor flag) in an instructor Teaching Call.

The default `teachingAssignmentRepository.delete()` method un-schedules the `teachingAssignment` deletion because of some cascade association.

Relevant: https://stackoverflow.com/questions/16898085/jpa-hibernate-remove-entity-sometimes-not-working